### PR TITLE
New configuration keys, manage multiple configurations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Company>Kentico</Company>
     <Authors>Eric Dugre</Authors>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <Product>Xperience by Kentico</Product>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following commands can be executed using the `xman` tool name:
 - [`m`, `macros`](#re-signing-macros)
 - [`b`, `build`](#building-projects)
 - [`g`, `generate`](#generating-code-for-object-types)
-- [`s`, `settings`](#modifying-appsettingsjson)
+- [`s`, `settings`](#modifying-application-settings)
 - [`ci <store> <restore>`](#running-continuous-integration)
 - [`cd <store> <restore> <config>`](#running-continuous-deployment)
 - [`p`, `profile <add> <delete> <switch>`](#managing-profiles)
@@ -129,9 +129,9 @@ Installing a new project automatically includes a database as well. If you want 
    xman delete
    ```
 
-### Modifying appsettings.json
+### Modifying application settings
 
-This tool can assist with changing the _CMSConnectionString_, supported [configuration keys](https://docs.xperience.io/xp/developers-and-admins/configuration/reference-configuration-keys), and the [headless API](https://docs.xperience.io/xp/developers-and-admins/configuration/headless-channel-management#Headlesschannelmanagement-ConfiguretheheadlessAPI).
+This tool can assist with changing the _CMSConnectionString_, supported [configuration keys](https://docs.xperience.io/xp/developers-and-admins/configuration/reference-configuration-keys), and the [headless API](https://docs.xperience.io/xp/developers-and-admins/configuration/headless-channel-management#Headlesschannelmanagement-ConfiguretheheadlessAPI). If your project has multiple application settings files (e.g. appsettings.Development.json), you will be prompted which file to modify.
 
 1. (optional) Select a profile with the [`profile`](#managing-profiles) command
 1. Run the `settings` command from the directory containing the [configuration file](#configuration-file), which will begin the settings wizard:

--- a/src/Commands/BuildCommand.cs
+++ b/src/Commands/BuildCommand.cs
@@ -49,7 +49,7 @@ namespace Xperience.Manager.Commands
 
         public override async Task PostExecute(ToolProfile? profile, string? action)
         {
-            if (!Errors.Any())
+            if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]Build complete![/]\n");
             }

--- a/src/Commands/CodeGenerateCommand.cs
+++ b/src/Commands/CodeGenerateCommand.cs
@@ -58,7 +58,7 @@ namespace Xperience.Manager.Commands
 
         public override async Task PostExecute(ToolProfile? profile, string? action)
         {
-            if (!Errors.Any())
+            if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]Code generation complete![/]\n");
             }
@@ -77,7 +77,10 @@ namespace Xperience.Manager.Commands
             // Add working directory to relative location
             options.Location = profile?.WorkingDirectory + options.Location;
 
-            string buildScript = scriptBuilder.SetScript(ScriptType.GenerateCode).WithPlaceholders(options).AppendNamespace(options.Namespace).Build();
+            string buildScript = scriptBuilder.SetScript(ScriptType.GenerateCode)
+                .WithPlaceholders(options)
+                .AppendNamespace(options.Namespace)
+                .Build();
             await shellRunner.Execute(new(buildScript)
             {
                 OutputHandler = (o, e) =>

--- a/src/Commands/ContinuousDeploymentCommand.cs
+++ b/src/Commands/ContinuousDeploymentCommand.cs
@@ -47,7 +47,12 @@ namespace Xperience.Manager.Commands
         }
 
 
-        public ContinuousDeploymentCommand(IWizard<RepositoryConfiguration> wizard, ICDXmlManager cdXmlManager, IShellRunner shellRunner, IScriptBuilder scriptBuilder, IConfigManager configManager)
+        public ContinuousDeploymentCommand(
+            IWizard<RepositoryConfiguration> wizard,
+            ICDXmlManager cdXmlManager,
+            IShellRunner shellRunner,
+            IScriptBuilder scriptBuilder,
+            IConfigManager configManager)
         {
             this.wizard = wizard;
             this.shellRunner = shellRunner;
@@ -143,6 +148,7 @@ namespace Xperience.Manager.Commands
             if (string.IsNullOrEmpty(profile?.ProjectName))
             {
                 LogError("Unable to load profile name.");
+
                 return;
             }
 
@@ -156,6 +162,7 @@ namespace Xperience.Manager.Commands
             if (repoConfig is null)
             {
                 LogError("Unable to read repository configuration.");
+
                 return;
             }
 
@@ -172,10 +179,13 @@ namespace Xperience.Manager.Commands
                 return null;
             }
 
-            var profiles = config.Profiles.Where(p => !p.ProjectName?.Equals(profile?.ProjectName, StringComparison.OrdinalIgnoreCase) ?? false);
+            var profiles = config.Profiles.Where(p =>
+                !p.ProjectName?.Equals(profile?.ProjectName, StringComparison.OrdinalIgnoreCase) ?? false);
             if (!profiles.Any())
             {
-                LogError("There are no profiles to restore CD data from. Use the 'install' or 'profile add' commands to register a new profile.");
+                LogError("There are no profiles to restore CD data from. Use the 'install' or 'profile add' commands to register a new " +
+                    "profile.");
+
                 return null;
             }
 
@@ -200,6 +210,7 @@ namespace Xperience.Manager.Commands
             if (string.IsNullOrEmpty(profile?.ProjectName))
             {
                 LogError("Unable to load profile name.");
+
                 return;
             }
 
@@ -235,6 +246,7 @@ namespace Xperience.Manager.Commands
             if (string.IsNullOrEmpty(sourceProfile.ProjectName))
             {
                 LogError("Unable to load profile name.");
+
                 return;
             }
 

--- a/src/Commands/ContinuousIntegrationCommand.cs
+++ b/src/Commands/ContinuousIntegrationCommand.cs
@@ -53,6 +53,7 @@ namespace Xperience.Manager.Commands
             if (string.IsNullOrEmpty(action) || !Parameters.Any(p => p.Equals(action, StringComparison.OrdinalIgnoreCase)))
             {
                 LogError($"Must provide one parameter from '{string.Join(", ", Parameters)}'");
+
                 return;
             }
 
@@ -104,7 +105,7 @@ namespace Xperience.Manager.Commands
 
         public override async Task PostExecute(ToolProfile? profile, string? action)
         {
-            if (!Errors.Any())
+            if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]CI {action ?? "process"} complete![/]\n");
             }
@@ -168,7 +169,9 @@ namespace Xperience.Manager.Commands
                 ErrorHandler = ErrorDataReceived,
                 OutputHandler = (o, e) =>
                 {
-                    if (e.Data?.Contains("The Continuous Integration repository is either not initialized or in an incorrect location on the file system.", StringComparison.OrdinalIgnoreCase) ?? false)
+                    string notFoundString = "The Continuous Integration repository is either not initialized or in an incorrect location on " +
+                        "the file system.";
+                    if (e.Data?.Contains(notFoundString, StringComparison.OrdinalIgnoreCase) ?? false)
                     {
                         // Restore process couldn't find repository directory
                         LogError("The restore process wasn't started because the Continuous Integration repository wasn't found.", o as Process);

--- a/src/Commands/DeleteCommand.cs
+++ b/src/Commands/DeleteCommand.cs
@@ -41,7 +41,11 @@ namespace Xperience.Manager.Commands
         }
 
 
-        public DeleteCommand(IShellRunner shellRunner, IScriptBuilder scriptBuilder, IConfigManager configManager, IAppSettingsManager appSettingsManager)
+        public DeleteCommand(
+            IShellRunner shellRunner,
+            IScriptBuilder scriptBuilder,
+            IConfigManager configManager,
+            IAppSettingsManager appSettingsManager)
         {
             this.shellRunner = shellRunner;
             this.scriptBuilder = scriptBuilder;
@@ -52,7 +56,8 @@ namespace Xperience.Manager.Commands
 
         public override async Task Execute(ToolProfile? profile, string? action)
         {
-            deleteConfirmed = AnsiConsole.Confirm($"This will [{Constants.ERROR_COLOR}]delete[/] the current profile's physical folder and database!\nDo you want to continue?", false);
+            deleteConfirmed = AnsiConsole.Confirm($"This will [{Constants.ERROR_COLOR}]delete[/] the current profile's physical folder " +
+                $"and database!\nDo you want to continue?", false);
             if (!deleteConfirmed)
             {
                 return;
@@ -74,7 +79,7 @@ namespace Xperience.Manager.Commands
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.EMPHASIS_COLOR}]Delete cancelled[/]\n");
             }
-            else if (!Errors.Any())
+            else if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]Delete complete![/]\n");
             }
@@ -96,15 +101,17 @@ namespace Xperience.Manager.Commands
             if (connString is null)
             {
                 LogError("Couldn't load connection string.");
+
                 return;
             }
 
             // Find "Initial Catalog" in connection string
-            IEnumerable<string> parts = connString.Split(';').ToList();
-            string? initialCatalogPart = parts.FirstOrDefault(p => p.ToLower().StartsWith("initial catalog"));
+            IEnumerable<string> parts = [.. connString.Split(';')];
+            string? initialCatalogPart = parts.FirstOrDefault(p => p.StartsWith("initial catalog", StringComparison.CurrentCultureIgnoreCase));
             if (initialCatalogPart is null)
             {
                 LogError("Couldn't find database name.");
+
                 return;
             }
 

--- a/src/Commands/InstallCommand.cs
+++ b/src/Commands/InstallCommand.cs
@@ -110,7 +110,7 @@ namespace Xperience.Manager.Commands
 
         public override async Task PostExecute(ToolProfile? profile, string? action)
         {
-            if (!Errors.Any())
+            if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]Install complete![/]\n");
             }
@@ -129,6 +129,7 @@ namespace Xperience.Manager.Commands
             if (string.IsNullOrEmpty(newInstallationProfile.WorkingDirectory))
             {
                 LogError("Unable to load working directory.");
+
                 return;
             }
 
@@ -198,6 +199,7 @@ namespace Xperience.Manager.Commands
                 }
             }).WaitForExitAsync();
         }
+
 
         private async Task InstallDatabaseTool()
         {

--- a/src/Commands/MacroCommand.cs
+++ b/src/Commands/MacroCommand.cs
@@ -75,7 +75,7 @@ namespace Xperience.Manager.Commands
 
         public override async Task PostExecute(ToolProfile? profile, string? action)
         {
-            if (!Errors.Any())
+            if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]Macros re-signed![/]\n");
             }

--- a/src/Commands/ProfileCommand.cs
+++ b/src/Commands/ProfileCommand.cs
@@ -54,6 +54,7 @@ namespace Xperience.Manager.Commands
             if (!Parameters.Any(p => p.Equals(action, StringComparison.OrdinalIgnoreCase)))
             {
                 LogError($"Must provide one parameter from '{string.Join(", ", Parameters)}'");
+
                 return;
             }
 
@@ -72,16 +73,18 @@ namespace Xperience.Manager.Commands
             var config = await configManager.GetConfig();
 
             // Can't switch or delete if there are no profiles
-            if (!config.Profiles.Any() &&
+            if (config.Profiles.Count == 0 &&
                 (action.Equals(SWITCH, StringComparison.OrdinalIgnoreCase) || action.Equals(DELETE, StringComparison.OrdinalIgnoreCase)))
             {
                 AnsiConsole.MarkupLineInterpolated($"There are no registered profiles. Install a new instance with [{Constants.SUCCESS_COLOR}]xman i[/] to add a profile.\n");
+
                 return;
             }
 
             if (config.Profiles.Count == 1 && action.Equals(SWITCH, StringComparison.OrdinalIgnoreCase))
             {
                 AnsiConsole.WriteLine("You're currently using the only registered profile.\n");
+
                 return;
             }
 
@@ -119,6 +122,7 @@ namespace Xperience.Manager.Commands
             if (!Directory.Exists(options.WorkingDirectory))
             {
                 LogError($"The directory {options.WorkingDirectory} couldn't be found.");
+
                 return;
             }
 

--- a/src/Commands/SettingsCommand.cs
+++ b/src/Commands/SettingsCommand.cs
@@ -142,6 +142,7 @@ namespace Xperience.Manager.Commands
             if (connString is null)
             {
                 LogError($"Unable to load connection string.");
+
                 return;
             }
 
@@ -169,6 +170,7 @@ namespace Xperience.Manager.Commands
                 if (updatedKey?.ActualValue is null)
                 {
                     LogError($"Failed to set new value for key {updatedKey?.KeyName}");
+
                     return;
                 }
 
@@ -202,11 +204,13 @@ namespace Xperience.Manager.Commands
             header.AppendLine($"\n{keyToUpdate.Description}\n");
             AnsiConsole.Write(new Markup(header.ToString()).Centered());
 
-            string newValue = AnsiConsole.Prompt(new TextPrompt<string>($"New value [{Constants.EMPHASIS_COLOR}]({keyToUpdate.ValueType.Name.ToLower()})[/]:"));
+            string newValue = AnsiConsole.Prompt(new TextPrompt<string>($"New value [{Constants.EMPHASIS_COLOR}]" +
+                $"({keyToUpdate.ValueType.Name.ToLower()})[/]:"));
             object converted = Convert.ChangeType(newValue, keyToUpdate.ValueType);
             if (converted is null)
             {
                 LogError($"The key value cannot be cast into type {keyToUpdate.ValueType.Name}");
+
                 return null;
             }
 
@@ -216,7 +220,10 @@ namespace Xperience.Manager.Commands
         }
 
 
-        private async Task<bool> TryUpdateHeadlessOption(CmsHeadlessConfiguration headlessConfiguration, PropertyInfo propToUpdate, ToolProfile? profile)
+        private async Task<bool> TryUpdateHeadlessOption(
+            CmsHeadlessConfiguration headlessConfiguration,
+            PropertyInfo propToUpdate,
+            ToolProfile? profile)
         {
             bool isCachingKey = headlessConfiguration.Caching.GetType().GetProperties().Contains(propToUpdate);
             object? value = isCachingKey ? propToUpdate.GetValue(headlessConfiguration.Caching) : propToUpdate.GetValue(headlessConfiguration);
@@ -234,11 +241,13 @@ namespace Xperience.Manager.Commands
 
             AnsiConsole.Write(new Markup(header.ToString()).Centered());
 
-            string newValue = AnsiConsole.Prompt(new TextPrompt<string>($"New value [{Constants.EMPHASIS_COLOR}]({propToUpdate.PropertyType.Name.ToLower()})[/]:"));
+            string newValue = AnsiConsole.Prompt(new TextPrompt<string>($"New value [{Constants.EMPHASIS_COLOR}]" +
+                $"({propToUpdate.PropertyType.Name.ToLower()})[/]:"));
             object converted = Convert.ChangeType(newValue, propToUpdate.PropertyType);
             if (converted is null)
             {
                 LogError($"The key value cannot be cast into type {propToUpdate.PropertyType.Name}");
+
                 return false;
             }
 

--- a/src/Commands/SettingsCommand.cs
+++ b/src/Commands/SettingsCommand.cs
@@ -63,11 +63,14 @@ namespace Xperience.Manager.Commands
                 case SettingsOptions.ConnectionStringSetting:
                     await ConfigureConnectionString(profile);
                     break;
-                case SettingsOptions.ConfigurationKeysSetting:
-                    await ConfigureKeys(profile);
+                case SettingsOptions.UngroupedKeySetting:
+                    await ConfigureKeys(profile, Constants.UngroupedKeys);
                     break;
                 case SettingsOptions.CmsHeadlessSetting:
                     await ConfigureHeadlessOptions(profile);
+                    break;
+                case SettingsOptions.AzureStorageSetting:
+                    await ConfigureKeys(profile, Constants.AzureStorageKeys);
                     break;
                 default:
                     LogError("Invalid selection.");
@@ -155,7 +158,7 @@ namespace Xperience.Manager.Commands
         }
 
 
-        private async Task ConfigureKeys(ToolProfile? profile)
+        private async Task ConfigureKeys(ToolProfile? profile, IEnumerable<ConfigurationKey> keysToList)
         {
             if (StopProcessing)
             {
@@ -163,7 +166,7 @@ namespace Xperience.Manager.Commands
             }
 
             bool updateSettings = true;
-            var keys = await appSettingsManager.GetConfigurationKeys(profile);
+            var keys = await appSettingsManager.GetConfigurationKeys(profile, keysToList);
             while (updateSettings)
             {
                 var updatedKey = GetNewSettingsKey(keys);

--- a/src/Commands/SettingsCommand.cs
+++ b/src/Commands/SettingsCommand.cs
@@ -201,6 +201,11 @@ namespace Xperience.Manager.Commands
                 header.AppendLine($"\nValue: {keyToUpdate.ActualValue}");
             }
 
+            if (keyToUpdate.DefaultValue is not null)
+            {
+                header.AppendLine($"\nDefault: {keyToUpdate.DefaultValue}");
+            }
+
             header.AppendLine($"\n{keyToUpdate.Description}\n");
             AnsiConsole.Write(new Markup(header.ToString()).Centered());
 

--- a/src/Commands/UpdateCommand.cs
+++ b/src/Commands/UpdateCommand.cs
@@ -75,7 +75,7 @@ namespace Xperience.Manager.Commands
 
         public override async Task PostExecute(ToolProfile? profile, string? action)
         {
-            if (!Errors.Any())
+            if (Errors.Count == 0)
             {
                 AnsiConsole.MarkupLineInterpolated($"[{Constants.SUCCESS_COLOR}]Update complete![/]\n");
             }

--- a/src/Configuration/CmsHeadlessConfiguration.cs
+++ b/src/Configuration/CmsHeadlessConfiguration.cs
@@ -15,7 +15,8 @@ namespace Xperience.Manager.Configuration
         public bool Enable { get; set; } = true;
 
 
-        [Display(Description = "Specifies whether GraphQL introspection is enabled (__schema queries and GUI tools for exploring the schema).")]
+        [Display(Description = "Specifies whether GraphQL introspection is enabled (__schema queries and GUI tools for exploring the " +
+            "schema).")]
         /// <summary>
         /// Specifies whether GraphQL introspection is enabled (__schema queries and GUI tools for exploring the schema).
         /// See <see href="https://graphql.org/learn/introspection/"/>.
@@ -38,7 +39,8 @@ namespace Xperience.Manager.Configuration
         public string? CorsAllowedOrigins { get; set; }
 
 
-        [Display(Description = "The HTTP headers that are allowed for content retrieval requests. If not set, all headers are allowed by default.")]
+        [Display(Description = "The HTTP headers that are allowed for content retrieval requests. If not set, all headers are allowed by " +
+            "default.")]
         /// <summary>
         /// The HTTP headers that are allowed for content retrieval requests. If not set, all headers are allowed by default.
         /// See <see href="https://docs.xperience.io/xp/developers-and-admins/development/content-retrieval/retrieve-headless-content"/>.
@@ -63,21 +65,24 @@ namespace Xperience.Manager.Configuration
             public bool Enable { get; set; } = true;
 
 
-            [Display(Name = "Caching::UseRequestCacheControlHeaders", Description = "Specifies whether caching respects the Cache-Control header of individual requests.")]
+            [Display(Name = "Caching::UseRequestCacheControlHeaders", Description = "Specifies whether caching respects the Cache-Control " +
+                "header of individual requests.")]
             /// <summary>
             /// Specifies whether caching respects the Cache-Control header of individual requests.
             /// </summary>
             public bool UseRequestCacheControlHeaders { get; set; } = true;
 
 
-            [Display(Name = "Caching::AddResponseCacheControlHeaders", Description = "Specifies whether caching sets the Cache-Control response header.")]
+            [Display(Name = "Caching::AddResponseCacheControlHeaders", Description = "Specifies whether caching sets the Cache-Control " +
+                "response header.")]
             /// <summary>
             /// Specifies whether caching sets the Cache-Control response header.
             /// </summary>
             public bool AddResponseCacheControlHeaders { get; set; } = true;
 
 
-            [Display(Name = "Caching::UseCacheDependencies", Description = "Specifies whether caching uses cache dependencies to flush the cache when data in a cached response changes.")]
+            [Display(Name = "Caching::UseCacheDependencies", Description = "Specifies whether caching uses cache dependencies to flush the " +
+                "cache when data in a cached response changes.")]
             /// <summary>
             /// Specifies whether caching uses cache dependencies to flush the cache when data in a cached response changes.
             /// </summary>
@@ -91,7 +96,8 @@ namespace Xperience.Manager.Configuration
             public int AbsoluteExpiration { get; set; } = 720;
 
 
-            [Display(Name = "Caching::SlidingExpiration", Description = "The sliding expiration date for cache entries in minutes. Cannot exceed the value of AbsoluteExpiration.")]
+            [Display(Name = "Caching::SlidingExpiration", Description = "The sliding expiration date for cache entries in minutes. Cannot " +
+                "exceed the value of AbsoluteExpiration.")]
             /// <summary>
             /// The sliding expiration date for cache entries in minutes. Cannot exceed the value of <see cref="AbsoluteExpiration"/>.
             /// </summary>

--- a/src/Configuration/CmsHeadlessConfiguration.cs
+++ b/src/Configuration/CmsHeadlessConfiguration.cs
@@ -3,7 +3,7 @@
 namespace Xperience.Manager.Configuration
 {
     /// <summary>
-    /// Represents the headless options specified in the appsettings.json. See
+    /// Represents the headless options specified in the application settings. See
     /// <see href="https://docs.xperience.io/xp/developers-and-admins/configuration/headless-channel-management#Headlesschannelmanagement-ConfiguretheheadlessAPI"/>.
     /// </summary>
     public class CmsHeadlessConfiguration

--- a/src/Configuration/CmsHeadlessConfiguration.cs
+++ b/src/Configuration/CmsHeadlessConfiguration.cs
@@ -15,6 +15,15 @@ namespace Xperience.Manager.Configuration
         public bool Enable { get; set; } = true;
 
 
+        [Display(Description = "Specifies whether complexity analysis is enabled.")]
+        public bool EnableComplexity { get; set; } = true;
+
+
+        [Display(Description = "Specifies whether Tracking API endpoints are enabled. Allows you to disable the tracking API while keeping " +
+            "the GraphQL API enabled.")]
+        public bool EnableTracking { get; set; } = true;
+
+
         [Display(Description = "Specifies whether GraphQL introspection is enabled (__schema queries and GUI tools for exploring the " +
             "schema).")]
         /// <summary>

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -4,6 +4,8 @@ namespace Xperience.Manager
 {
     public static class Constants
     {
+        public const int MIN_LISTED_VERSION = 28;
+
         public const string CONFIG_FILENAME = "xman.json";
 
         public const string CD_FILES_DIR = "CDRepository";
@@ -35,7 +37,8 @@ namespace Xperience.Manager
                 typeof(string),
                 "bmp;gif;ico;png;wmf;jpg;jpeg;tiff;tif;webp"),
             new("CMSLogKeepPercent",
-                "This key determines the extra percentage of events that is retained in the log over the specified limit. This percentage of the oldest events is deleted by batch when the percentage is exceeded",
+                "This key determines the extra percentage of events that is retained in the log over the specified limit. This percentage " +
+                    "of the oldest events is deleted by batch when the percentage is exceeded",
                 typeof(int),
                 10),
             new("CMSCIEncoding",

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -41,6 +41,10 @@ namespace Xperience.Manager
                     "of the oldest events is deleted by batch when the percentage is exceeded",
                 typeof(int),
                 10),
+            new("CMSBuilderScriptsIncludeJQuery",
+                "Determines whether the system links the jQuery 3.5.1 library to live site pages containing Page Builder content or forms",
+                typeof(bool),
+                false),
             new("CMSCIEncoding",
                 "Sets the character encoding used when the CI/CD features generate non-binary files in the repository folder",
                 typeof(string),
@@ -60,7 +64,19 @@ namespace Xperience.Manager
             new("CMSEmailUrlDefaultScheme",
                 "Sets the scheme (protocol) used when resolving relative URLs within email content",
                 typeof(string),
-                "https")
+                "https"),
+            new("CMSDeleteTemporaryUploadFilesOlderThan",
+                "Sets the interval (in hours) at which the system deletes the contents of the temporary folder that stores files uploaded " +
+                    "through the Upload file component in Form Builder.",
+                typeof(int),
+                2),
+            new("CMSPhysicalFilesCacheMinutes",
+                "Sets client cache expiration time (in minutes) for physical files served by Xperience through the GetResource handler.",
+                typeof(int),
+                10_080),
+            new("CMSStorageProviderAssembly",
+                "Configures the assembly name of a custom file system provider.",
+                typeof(string))
         ];
     }
 }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -28,7 +28,7 @@ namespace Xperience.Manager
 
 
         /// <summary>
-        /// Configuration keys saved on the root of the appsettings.json file and are all associated with Azure storage.
+        /// Configuration keys saved on the root of the application settings file and are all associated with Azure storage.
         /// </summary>
         public static IEnumerable<ConfigurationKey> AzureStorageKeys =>
         [
@@ -64,7 +64,7 @@ namespace Xperience.Manager
 
 
         /// <summary>
-        /// Configuration keys saved on the root of the appsettings.json file, but are not associated with common features.
+        /// Configuration keys saved on the root of the application settings file, but are not associated with common features.
         /// </summary>
         public static IEnumerable<ConfigurationKey> UngroupedKeys =>
         [

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -4,6 +4,9 @@ namespace Xperience.Manager
 {
     public static class Constants
     {
+        /// <summary>
+        /// The lowest major version listed for installation or updating.
+        /// </summary>
         public const int MIN_LISTED_VERSION = 28;
 
         public const string CONFIG_FILENAME = "xman.json";
@@ -68,7 +71,7 @@ namespace Xperience.Manager
             new("CMSForbiddenURLValues",
                 "Specifies characters that are forbidden in page URLs",
                 typeof(string),
-                "\\/:*?\"<>|&%.'#[]+ \t=„“"),
+                "\\/:*?\"<>|&%.'#[]+ =„“"),
             new("CMSHashStringSalt",
                 "Sets the salt value the system uses in hash functions, for example when creating macro signatures",
                 typeof(string)),

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -23,7 +23,47 @@ namespace Xperience.Manager
         public const string TEMPLATE_BLANK = "kentico-xperience-mvc";
         public const string TEMPLATE_ADMIN = "kentico-xperience-admin-sample";
 
-        public static IEnumerable<ConfigurationKey> ConfigurationKeys =>
+
+        /// <summary>
+        /// Configuration keys saved on the root of the appsettings.json file and are all associated with Azure storage.
+        /// </summary>
+        public static IEnumerable<ConfigurationKey> AzureStorageKeys =>
+        [
+            new("CMSAzureAccountName",
+                "The Azure storage account name",
+                typeof(string)),
+            new("CMSAzureSharedKey",
+                "The Azure storage account shared key",
+                typeof(string)),
+            new("CMSAzureTempPath",
+                "The system uses the specified folder to store temporary files on a local disk, for example when transferring large files " +
+                    "to or from the storage account. If not set, the system creates and uses an ~/AzureTemp directory in the project’s root",
+                typeof(string)),
+            new("CMSAzureCachePath",
+                "Specifies a folder on a local disk where files requested from the storage account are cached. This helps minimize the " +
+                    "amount of blob storage operations, which saves time and resources. If not set, the system creates and uses an " +
+                    "~/AzureCache directory in the project’s root",
+                typeof(string)),
+            new("CMSAzureBlobEndPoint",
+                "Sets the endpoint used for the connection to the blob service of the specified storage account. If you wish to use the " +
+                    "default endpoint, remove the setting completely from the appropriate files",
+                typeof(string)),
+            new("CMSAzurePublicContainer",
+                "Indicates if the blob container used to store the application’s files is public. If true, it will be possible to access " +
+                    "files directly through the URL of the appropriate blob service, for example: https://<StorageAccountName>.blob.core." +
+                    "windows.net/media/imagelibrary/logo.png",
+                typeof(bool)),
+            new("CMSDownloadBlobTimeout",
+                "Specifies the timeout interval in minutes for importing files from Azure Blob storage into Xperience. The default is 1.5 " +
+                    "minutes. Increase the interval if you encounter problems when importing large files (2GB+).",
+                typeof(int))
+        ];
+
+
+        /// <summary>
+        /// Configuration keys saved on the root of the appsettings.json file, but are not associated with common features.
+        /// </summary>
+        public static IEnumerable<ConfigurationKey> UngroupedKeys =>
         [
             new("CMSForbiddenURLValues",
                 "Specifies characters that are forbidden in page URLs",

--- a/src/Options/CodeGenerateOptions.cs
+++ b/src/Options/CodeGenerateOptions.cs
@@ -46,7 +46,8 @@ namespace Xperience.Manager.Options
 
 
         /// <summary>
-        /// The custom namespace added to the code of the generated classes. If not provided, a default system namespace is used based on the generated object type.
+        /// The custom namespace added to the code of the generated classes. If not provided, a default system namespace is used based on 
+        /// the generated object type.
         /// </summary>
         public string? Namespace { get; set; }
     }

--- a/src/Options/SettingsOptions.cs
+++ b/src/Options/SettingsOptions.cs
@@ -9,7 +9,8 @@ namespace Xperience.Manager.Options
     {
         public const string CmsHeadlessSetting = "CMSHeadless options";
         public const string ConnectionStringSetting = "Connection string";
-        public const string ConfigurationKeysSetting = "Configuration keys";
+        public const string UngroupedKeySetting = "Configuration keys";
+        public const string AzureStorageSetting = "Azure storage";
 
 
         /// <summary>

--- a/src/Options/SettingsOptions.cs
+++ b/src/Options/SettingsOptions.cs
@@ -3,7 +3,7 @@
 namespace Xperience.Manager.Options
 {
     /// <summary>
-    /// The options used to configure the appsettings.json file, used by <see cref="SettingsCommand"/>.
+    /// The options used to configure the application settings file, used by <see cref="SettingsCommand"/>.
     /// </summary>
     public class SettingsOptions : IWizardOptions
     {
@@ -14,8 +14,14 @@ namespace Xperience.Manager.Options
 
 
         /// <summary>
-        /// The section of the appsettings.json the user wants to configure.
+        /// The section of the application settings the user wants to configure.
         /// </summary>
         public string? SettingToChange { get; set; }
+
+
+        /// <summary>
+        /// The name of the file to modify.
+        /// </summary>
+        public string? AppSettingsFileName { get; set; }
     }
 }

--- a/src/Repositories/CommandRepository.cs
+++ b/src/Repositories/CommandRepository.cs
@@ -13,7 +13,8 @@ namespace Xperience.Manager.Repositories
         public CommandRepository(IEnumerable<ICommand> commands) => this.commands = commands;
 
 
-        public ICommand? Get(string keyword) => commands.FirstOrDefault(c => c?.Keywords.Contains(keyword, StringComparer.OrdinalIgnoreCase) ?? false);
+        public ICommand? Get(string keyword) => commands.FirstOrDefault(c => c?.Keywords.Contains(keyword, StringComparer.OrdinalIgnoreCase)
+            ?? false);
 
 
         public IEnumerable<ICommand> GetAll() => commands;

--- a/src/Services/AppSettingsManager.cs
+++ b/src/Services/AppSettingsManager.cs
@@ -62,7 +62,8 @@ namespace Xperience.Manager.Services
         public async Task SetConnectionString(ToolProfile? profile, string name, string connectionString)
         {
             var appSettings = await LoadSettings(profile);
-            var connectionStrings = appSettings["ConnectionStrings"] ?? throw new InvalidOperationException("ConnectionStrings section not found.");
+            var connectionStrings = appSettings["ConnectionStrings"]
+                ?? throw new InvalidOperationException("ConnectionStrings section not found.");
             connectionStrings[name] = connectionString;
 
             await WriteAppSettings(profile, appSettings);
@@ -81,15 +82,8 @@ namespace Xperience.Manager.Services
         private static string GetAppSettingsPath(ToolProfile profile) => $"{profile.WorkingDirectory}/appsettings.json";
 
 
-        private static Task<JObject> LoadSettings(ToolProfile? profile)
-        {
-            if (profile is null)
-            {
-                throw new ArgumentNullException(nameof(profile));
-            }
-
-            return LoadSettingsInternal(profile);
-        }
+        private static Task<JObject> LoadSettings(ToolProfile? profile) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : LoadSettingsInternal(profile);
 
 
         private static async Task<JObject> LoadSettingsInternal(ToolProfile profile)
@@ -102,19 +96,13 @@ namespace Xperience.Manager.Services
 
             string text = await File.ReadAllTextAsync(settingsPath);
 
-            return JsonConvert.DeserializeObject<JObject>(text) ?? throw new InvalidOperationException("Failed to deserialize appsettings.json");
+            return JsonConvert.DeserializeObject<JObject>(text)
+                ?? throw new InvalidOperationException("Failed to deserialize appsettings.json");
         }
 
 
-        private static Task WriteAppSettings(ToolProfile? profile, JObject appSettings)
-        {
-            if (profile is null)
-            {
-                throw new ArgumentNullException(nameof(profile));
-            }
-
-            return WriteAppSettingsInternal(profile, appSettings);
-        }
+        private static Task WriteAppSettings(ToolProfile? profile, JObject appSettings) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : WriteAppSettingsInternal(profile, appSettings);
 
 
         private static async Task WriteAppSettingsInternal(ToolProfile profile, JObject appSettings)

--- a/src/Services/AppSettingsManager.cs
+++ b/src/Services/AppSettingsManager.cs
@@ -7,26 +7,27 @@ namespace Xperience.Manager.Services
 {
     public class AppSettingsManager : IAppSettingsManager
     {
-        private readonly string cmsHeadlessSection = "CMSHeadless";
+        private const string CMS_HEADLESS_SECTION = "CMSHeadless";
+        private const string DEFAULT_FILENAME = "appsettings.json";
 
 
-        public async Task<string?> GetConnectionString(ToolProfile? profile, string name)
+        public async Task<string?> GetConnectionString(ToolProfile? profile, string connectionStringName, string? fileName = null)
         {
-            var appSettings = await LoadSettings(profile);
+            var appSettings = await LoadSettings(profile, fileName);
             var connectionStrings = appSettings["ConnectionStrings"];
             if (connectionStrings is null)
             {
                 return null;
             }
 
-            return connectionStrings.Value<string>(name);
+            return connectionStrings.Value<string>(connectionStringName);
         }
 
 
-        public async Task<CmsHeadlessConfiguration> GetCmsHeadlessConfiguration(ToolProfile? profile)
+        public async Task<CmsHeadlessConfiguration> GetCmsHeadlessConfiguration(ToolProfile? profile, string? fileName = null)
         {
-            var appSettings = await LoadSettings(profile);
-            var headlessConfig = appSettings.GetValue(cmsHeadlessSection)?.ToObject<CmsHeadlessConfiguration>();
+            var appSettings = await LoadSettings(profile, fileName);
+            var headlessConfig = appSettings.GetValue(CMS_HEADLESS_SECTION)?.ToObject<CmsHeadlessConfiguration>();
             if (headlessConfig is null)
             {
                 return new CmsHeadlessConfiguration();
@@ -36,9 +37,12 @@ namespace Xperience.Manager.Services
         }
 
 
-        public async Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(ToolProfile? profile, IEnumerable<ConfigurationKey> keys)
+        public async Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(
+            ToolProfile? profile,
+            IEnumerable<ConfigurationKey> keys,
+            string? fileName = null)
         {
-            var appSettings = await LoadSettings(profile);
+            var appSettings = await LoadSettings(profile, fileName);
             var populatedKeys = keys
                 .Where(key => appSettings.Properties().Select(p => p.Name).Contains(key.KeyName, StringComparer.OrdinalIgnoreCase))
                 .Select(key => { key.ActualValue = appSettings.GetValue(key.KeyName)?.Value<object>(); return key; });
@@ -50,45 +54,53 @@ namespace Xperience.Manager.Services
         }
 
 
-        public async Task SetCmsHeadlessConfiguration(ToolProfile? profile, CmsHeadlessConfiguration headlessConfiguration)
+        public async Task SetCmsHeadlessConfiguration(
+            ToolProfile? profile,
+            CmsHeadlessConfiguration headlessConfiguration,
+            string? fileName = null)
         {
-            var appSettings = await LoadSettings(profile);
-            appSettings[cmsHeadlessSection] = JToken.FromObject(headlessConfiguration);
+            var appSettings = await LoadSettings(profile, fileName);
+            appSettings[CMS_HEADLESS_SECTION] = JToken.FromObject(headlessConfiguration);
 
-            await WriteAppSettings(profile, appSettings);
+            await WriteAppSettings(profile, appSettings, fileName);
         }
 
 
-        public async Task SetConnectionString(ToolProfile? profile, string name, string connectionString)
+        public async Task SetConnectionString(
+            ToolProfile? profile,
+            string connectionStringName,
+            string connectionString,
+            string? fileName = null)
         {
-            var appSettings = await LoadSettings(profile);
+            var appSettings = await LoadSettings(profile, fileName);
             var connectionStrings = appSettings["ConnectionStrings"]
                 ?? throw new InvalidOperationException("ConnectionStrings section not found.");
-            connectionStrings[name] = connectionString;
+            connectionStrings[connectionStringName] = connectionString;
 
-            await WriteAppSettings(profile, appSettings);
+            await WriteAppSettings(profile, appSettings, fileName);
         }
 
 
-        public async Task SetKeyValue(ToolProfile? profile, string keyName, object value)
+        public async Task SetKeyValue(ToolProfile? profile, string keyName, object value, string? fileName = null)
         {
-            var appSettings = await LoadSettings(profile);
+            var appSettings = await LoadSettings(profile, fileName);
             appSettings[keyName] = JToken.FromObject(value);
 
-            await WriteAppSettings(profile, appSettings);
+            await WriteAppSettings(profile, appSettings, fileName);
         }
 
 
-        private static string GetAppSettingsPath(ToolProfile profile) => $"{profile.WorkingDirectory}/appsettings.json";
+        private static string GetAppSettingsPath(ToolProfile profile, string? fileName) =>
+            $"{profile.WorkingDirectory}/{fileName ?? DEFAULT_FILENAME}";
 
 
-        private static Task<JObject> LoadSettings(ToolProfile? profile) =>
-            profile is null ? throw new ArgumentNullException(nameof(profile)) : LoadSettingsInternal(profile);
+        private static Task<JObject> LoadSettings(ToolProfile? profile, string? fileName) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : LoadSettingsInternal(profile, fileName);
 
 
-        private static async Task<JObject> LoadSettingsInternal(ToolProfile profile)
+        private static async Task<JObject> LoadSettingsInternal(ToolProfile profile, string? fileName)
         {
-            string settingsPath = GetAppSettingsPath(profile);
+            string settingsPath = GetAppSettingsPath(profile, fileName);
             if (!File.Exists(settingsPath))
             {
                 throw new InvalidOperationException($"Settings not found at {settingsPath}.");
@@ -97,17 +109,17 @@ namespace Xperience.Manager.Services
             string text = await File.ReadAllTextAsync(settingsPath);
 
             return JsonConvert.DeserializeObject<JObject>(text)
-                ?? throw new InvalidOperationException("Failed to deserialize appsettings.json");
+                ?? throw new InvalidOperationException($"Failed to deserialize {fileName ?? DEFAULT_FILENAME}");
         }
 
 
-        private static Task WriteAppSettings(ToolProfile? profile, JObject appSettings) =>
-            profile is null ? throw new ArgumentNullException(nameof(profile)) : WriteAppSettingsInternal(profile, appSettings);
+        private static Task WriteAppSettings(ToolProfile? profile, JObject appSettings, string? fileName) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : WriteAppSettingsInternal(profile, appSettings, fileName);
 
 
-        private static async Task WriteAppSettingsInternal(ToolProfile profile, JObject appSettings)
+        private static async Task WriteAppSettingsInternal(ToolProfile profile, JObject appSettings, string? fileName)
         {
-            string settingsPath = GetAppSettingsPath(profile);
+            string settingsPath = GetAppSettingsPath(profile, fileName);
 
             await File.WriteAllTextAsync(settingsPath, JsonConvert.SerializeObject(appSettings, Formatting.Indented));
         }

--- a/src/Services/AppSettingsManager.cs
+++ b/src/Services/AppSettingsManager.cs
@@ -36,15 +36,15 @@ namespace Xperience.Manager.Services
         }
 
 
-        public async Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(ToolProfile? profile)
+        public async Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(ToolProfile? profile, IEnumerable<ConfigurationKey> keys)
         {
             var appSettings = await LoadSettings(profile);
-            var populatedKeys = Constants.ConfigurationKeys
+            var populatedKeys = keys
                 .Where(key => appSettings.Properties().Select(p => p.Name).Contains(key.KeyName, StringComparer.OrdinalIgnoreCase))
                 .Select(key => { key.ActualValue = appSettings.GetValue(key.KeyName)?.Value<object>(); return key; });
             var allKeys = new List<ConfigurationKey>(populatedKeys);
 
-            allKeys.AddRange(Constants.ConfigurationKeys.Where(key => !populatedKeys.Select(k => k.KeyName).Contains(key.KeyName)));
+            allKeys.AddRange(keys.Where(key => !populatedKeys.Select(k => k.KeyName).Contains(key.KeyName)));
 
             return allKeys;
         }

--- a/src/Services/ConfigManager.cs
+++ b/src/Services/ConfigManager.cs
@@ -10,32 +10,19 @@ namespace Xperience.Manager.Services
 {
     public class ConfigManager : IConfigManager
     {
-        public Task AddProfile(ToolProfile? profile)
-        {
-            if (profile is null)
-            {
-                throw new ArgumentNullException(nameof(profile));
-            }
-
-            return AddProfileInternal(profile);
-        }
+        public Task AddProfile(ToolProfile? profile) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : AddProfileInternal(profile);
 
 
-        public Task SetCurrentProfile(ToolProfile? profile)
-        {
-            if (profile is null)
-            {
-                throw new ArgumentNullException(nameof(profile));
-            }
-
-            return SetCurrentProfileInternal(profile);
-        }
+        public Task SetCurrentProfile(ToolProfile? profile) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : SetCurrentProfileInternal(profile);
 
 
         public async Task<ToolProfile?> GetCurrentProfile()
         {
             var config = await GetConfig();
-            var match = config.Profiles.FirstOrDefault(p => p.ProjectName?.Equals(config.CurrentProfile, StringComparison.OrdinalIgnoreCase) ?? false);
+            var match = config.Profiles.FirstOrDefault(p =>
+                p.ProjectName?.Equals(config.CurrentProfile, StringComparison.OrdinalIgnoreCase) ?? false);
             if (config.Profiles.Count == 1 &&
                 (string.IsNullOrEmpty(config.CurrentProfile) || match is null))
             {
@@ -62,7 +49,8 @@ namespace Xperience.Manager.Services
             }
 
             string text = await File.ReadAllTextAsync(Constants.CONFIG_FILENAME);
-            var config = JsonConvert.DeserializeObject<ToolConfiguration>(text) ?? throw new JsonReaderException($"The configuration file {Constants.CONFIG_FILENAME} cannot be deserialized.");
+            var config = JsonConvert.DeserializeObject<ToolConfiguration>(text) ?? throw new JsonReaderException($"The configuration " +
+                $"file {Constants.CONFIG_FILENAME} cannot be deserialized.");
 
             return config;
         }
@@ -75,6 +63,7 @@ namespace Xperience.Manager.Services
             if (File.Exists(Constants.CONFIG_FILENAME))
             {
                 await MigrateConfig(toolVersion);
+
                 return;
             }
 
@@ -103,15 +92,8 @@ namespace Xperience.Manager.Services
         }
 
 
-        public Task RemoveProfile(ToolProfile? profile)
-        {
-            if (profile is null)
-            {
-                throw new ArgumentNullException(nameof(profile));
-            }
-
-            return RemoveProfileInternal(profile);
-        }
+        public Task RemoveProfile(ToolProfile? profile) =>
+            profile is null ? throw new ArgumentNullException(nameof(profile)) : RemoveProfileInternal(profile);
 
 
         private async Task AddProfileInternal(ToolProfile profile)
@@ -157,7 +139,8 @@ namespace Xperience.Manager.Services
 
             // For some reason Profiles.Remove() didn't work, make a new list
             var newProfiles = new List<ToolProfile>();
-            newProfiles.AddRange(config.Profiles.Where(p => !p.ProjectName?.Equals(profile.ProjectName, StringComparison.OrdinalIgnoreCase) ?? true));
+            newProfiles.AddRange(config.Profiles.Where(p =>
+                !p.ProjectName?.Equals(profile.ProjectName, StringComparison.OrdinalIgnoreCase) ?? true));
 
             config.Profiles = newProfiles;
 

--- a/src/Services/Interfaces/IAppSettingsManager.cs
+++ b/src/Services/Interfaces/IAppSettingsManager.cs
@@ -21,10 +21,11 @@ namespace Xperience.Manager.Services
 
 
         /// <summary>
-        /// Gets configurations keys. See
+        /// Gets configurations keys with their <see cref="ConfigurationKey.ActualValue"/> set if available. See
         /// <see href="https://docs.xperience.io/xp/developers-and-admins/configuration/reference-configuration-keys"/>.
         /// </summary>
-        public Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(ToolProfile? profile);
+        /// <param name="keys">The keys to retrieve.</param>
+        public Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(ToolProfile? profile, IEnumerable<ConfigurationKey> keys);
 
 
         /// <summary>

--- a/src/Services/Interfaces/IAppSettingsManager.cs
+++ b/src/Services/Interfaces/IAppSettingsManager.cs
@@ -3,46 +3,74 @@
 namespace Xperience.Manager.Services
 {
     /// <summary>
-    /// Contains methods for interfacing with the appsettings.json of a project.
+    /// Contains methods for interfacing with the application settings of a project.
     /// </summary>
     public interface IAppSettingsManager : IService
     {
         /// <summary>
-        /// Gets the value of the connection string specified by the <paramref name="name"/>.
+        /// Gets the provided connection string.
         /// </summary>
-        public Task<string?> GetConnectionString(ToolProfile? profile, string name);
+        /// <param name="profile">The tool profile.</param>
+        /// <param name="connectionStringName">The name of the connection string to retrieve.</param>
+        /// <param name="fileName">The application settings file to read. If not provided, the appsettings.json file is used.</param>
+        public Task<string?> GetConnectionString(ToolProfile? profile, string connectionStringName, string? fileName = null);
 
 
         /// <summary>
         /// Gets the headless options. See
         /// <see href="https://docs.xperience.io/xp/developers-and-admins/configuration/headless-channel-management#Headlesschannelmanagement-ConfiguretheheadlessAPI"/>.
         /// </summary>
-        public Task<CmsHeadlessConfiguration> GetCmsHeadlessConfiguration(ToolProfile? profile);
+        /// <param name="profile">The tool profile.</param>
+        /// <param name="fileName">The application settings file to read. If not provided, the appsettings.json file is used.</param>
+        public Task<CmsHeadlessConfiguration> GetCmsHeadlessConfiguration(ToolProfile? profile, string? fileName = null);
 
 
         /// <summary>
         /// Gets configurations keys with their <see cref="ConfigurationKey.ActualValue"/> set if available. See
         /// <see href="https://docs.xperience.io/xp/developers-and-admins/configuration/reference-configuration-keys"/>.
         /// </summary>
+        /// <param name="profile">The tool profile.</param>
         /// <param name="keys">The keys to retrieve.</param>
-        public Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(ToolProfile? profile, IEnumerable<ConfigurationKey> keys);
+        /// <param name="fileName">The application settings file to read. If not provided, the appsettings.json file is used.</param>
+        public Task<IEnumerable<ConfigurationKey>> GetConfigurationKeys(
+            ToolProfile? profile,
+            IEnumerable<ConfigurationKey> keys,
+            string? fileName = null);
 
 
         /// <summary>
-        /// Writes the headless configuration to the appsettings.json.
+        /// Writes the headless configuration to the application settings.
         /// </summary>
-        public Task SetCmsHeadlessConfiguration(ToolProfile? profile, CmsHeadlessConfiguration headlessConfiguration);
+        /// <param name="profile">The tool profile.</param>
+        /// <param name="headlessConfiguration">The configuration to write.</param>
+        /// <param name="fileName">The application settings file to write to. If not provided, the appsettings.json file is used.</param>
+        public Task SetCmsHeadlessConfiguration(
+            ToolProfile? profile,
+            CmsHeadlessConfiguration headlessConfiguration,
+            string? fileName = null);
 
 
         /// <summary>
-        /// Writes the connection string to the appsettings.json.
+        /// Writes the connection string to the application settings.
         /// </summary>
-        public Task SetConnectionString(ToolProfile? profile, string name, string connectionString);
+        /// <param name="profile">The tool profile.</param>
+        /// <param name="connectionStringName">The name of the connection string to write.</param>
+        /// <param name="connectionString">The value of the connection string.</param>
+        /// <param name="fileName">The application settings file to write. If not provided, the appsettings.json file is used.</param>
+        public Task SetConnectionString(
+            ToolProfile? profile,
+            string connectionStringName,
+            string connectionString,
+            string? fileName = null);
 
 
         /// <summary>
-        /// Writes a configuration key value to the appsettings.json.
+        /// Writes a configuration key value to the application settings.
         /// </summary>
-        public Task SetKeyValue(ToolProfile? profile, string keyName, object value);
+        /// <param name="profile">The tool profile.</param>
+        /// <param name="keyName">The name of the key to write.</param>
+        /// <param name="value">The value of the key.</param>
+        /// <param name="fileName">The application settings file to write. If not provided, the appsettings.json file is used.</param>
+        public Task SetKeyValue(ToolProfile? profile, string keyName, object value, string? fileName = null);
     }
 }

--- a/src/Services/ScriptBuilder.cs
+++ b/src/Services/ScriptBuilder.cs
@@ -10,8 +10,11 @@ namespace Xperience.Manager.Services
 
         private const string BUILD_SCRIPT = "dotnet build";
         private const string MKDIR_SCRIPT = $"mkdir";
-        private const string INSTALL_PROJECT_SCRIPT = $"dotnet new {nameof(InstallProjectOptions.Template)} -n {nameof(InstallProjectOptions.ProjectName)}";
-        private const string INSTALL_DATABASE_SCRIPT = $"dotnet kentico-xperience-dbmanager -- -s \"{nameof(InstallDatabaseOptions.ServerName)}\" -d \"{nameof(InstallDatabaseOptions.DatabaseName)}\" -a \"{nameof(InstallDatabaseOptions.AdminPassword)}\" --use-existing-database {nameof(InstallDatabaseOptions.UseExistingDatabase)}";
+        private const string INSTALL_PROJECT_SCRIPT = $"dotnet new {nameof(InstallProjectOptions.Template)} -n " +
+            $"{nameof(InstallProjectOptions.ProjectName)}";
+        private const string INSTALL_DATABASE_SCRIPT = $"dotnet kentico-xperience-dbmanager -- -s \"" +
+            $"{nameof(InstallDatabaseOptions.ServerName)}\" -d \"{nameof(InstallDatabaseOptions.DatabaseName)}\" -a \"" +
+            $"{nameof(InstallDatabaseOptions.AdminPassword)}\" --use-existing-database {nameof(InstallDatabaseOptions.UseExistingDatabase)}";
         private const string UNINSTALL_TEMPLATE_SCRIPT = $"dotnet new uninstall {Constants.TEMPLATES_PACKAGE}";
         private const string INSTALL_TEMPLATE_SCRIPT = $"dotnet new install {Constants.TEMPLATES_PACKAGE}";
         private const string UPDATE_PACKAGE_SCRIPT = $"dotnet add package {nameof(UpdateOptions.PackageName)}";
@@ -20,13 +23,19 @@ namespace Xperience.Manager.Services
         private const string UNINSTALL_DBTOOL_SCRIPT = $"dotnet tool uninstall {Constants.DATABASE_TOOL} -g";
         private const string CI_STORE_SCRIPT = "dotnet run --no-build --kxp-ci-store";
         private const string CI_RESTORE_SCRIPT = "dotnet run --no-build --kxp-ci-restore";
-        private const string CD_NEW_CONFIG_SCRIPT = $"dotnet run --no-build -- --kxp-cd-config --path \"{nameof(ContinuousDeploymentConfig.ConfigPath)}\"";
-        private const string CD_STORE_SCRIPT = $"dotnet run --no-build -- --kxp-cd-store --repository-path \"{nameof(ContinuousDeploymentConfig.RepositoryPath)}\" --config-path \"{nameof(ContinuousDeploymentConfig.ConfigPath)}\"";
-        private const string CD_RESTORE_SCRIPT = $"dotnet run -- --kxp-cd-restore --repository-path \"{nameof(ContinuousDeploymentConfig.RepositoryPath)}\"";
+        private const string CD_NEW_CONFIG_SCRIPT = $"dotnet run --no-build -- --kxp-cd-config --path \"" +
+            $"{nameof(ContinuousDeploymentConfig.ConfigPath)}\"";
+        private const string CD_STORE_SCRIPT = $"dotnet run --no-build -- --kxp-cd-store --repository-path \"" +
+            $"{nameof(ContinuousDeploymentConfig.RepositoryPath)}\" --config-path \"{nameof(ContinuousDeploymentConfig.ConfigPath)}\"";
+        private const string CD_RESTORE_SCRIPT = $"dotnet run -- --kxp-cd-restore --repository-path \"" +
+            $"{nameof(ContinuousDeploymentConfig.RepositoryPath)}\"";
         private const string MACRO_SCRIPT = "dotnet run --no-build -- --kxp-resign-macros";
-        private const string CODEGEN_SCRIPT = $"dotnet run -- --kxp-codegen --skip-confirmation --type \"{nameof(CodeGenerateOptions.Type)}\" --location \"{nameof(CodeGenerateOptions.Location)}\" --include \"{nameof(CodeGenerateOptions.Include)}\" --exclude \"{nameof(CodeGenerateOptions.Exclude)}\" --with-provider-class {nameof(CodeGenerateOptions.WithProviderClass)}";
+        private const string CODEGEN_SCRIPT = $"dotnet run -- --kxp-codegen --skip-confirmation --type \"{nameof(CodeGenerateOptions.Type)}" +
+            $"\" --location \"{nameof(CodeGenerateOptions.Location)}\" --include \"{nameof(CodeGenerateOptions.Include)}\" --exclude \"" +
+            $"{nameof(CodeGenerateOptions.Exclude)}\" --with-provider-class {nameof(CodeGenerateOptions.WithProviderClass)}";
         private const string DELETE_FOLDER_SCRIPT = $"rm \"{nameof(ToolProfile.WorkingDirectory)}\" -r -Force";
-        private const string RUN_SQL_QUERY = $"Invoke-Sqlcmd -ConnectionString \"{nameof(RunSqlOptions.ConnString)}\" -Query \"{nameof(RunSqlOptions.SqlQuery)}\"";
+        private const string RUN_SQL_QUERY = $"Invoke-Sqlcmd -ConnectionString \"{nameof(RunSqlOptions.ConnString)}\" -Query \"" +
+            $"{nameof(RunSqlOptions.SqlQuery)}\"";
 
 
         public IScriptBuilder AppendCloud(bool useCloud)

--- a/src/Steps/StepList.cs
+++ b/src/Steps/StepList.cs
@@ -23,6 +23,7 @@
             if (currentIndex < Count - 1)
             {
                 Step(1);
+
                 return true;
             }
 
@@ -39,6 +40,7 @@
             if (currentIndex > 0)
             {
                 Step(-1);
+
                 return true;
             }
 

--- a/src/Wizards/CodeGenerateWizard.cs
+++ b/src/Wizards/CodeGenerateWizard.cs
@@ -51,20 +51,22 @@ namespace Xperience.Manager.Wizards
             {
                 Prompt = new TextPrompt<string>($"Enter the relative [{Constants.PROMPT_COLOR}]location[/] to generate files:")
                     .DefaultValue(Options.Location)
-                    .Validate((v) => v.StartsWith("/"))
+                    .Validate((v) => v.StartsWith('/'))
                     .ValidationErrorMessage("Location must start with '/'"),
                 ValueReceiver = (v) => Options.Location = v
             }));
 
             Steps.Add(new Step<string>(new()
             {
-                Prompt = new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Include[/] which object types (semicolon separated list)?").DefaultValue(Options.Include),
+                Prompt = new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Include[/] which object types (semicolon separated list)?")
+                    .DefaultValue(Options.Include),
                 ValueReceiver = (v) => Options.Include = v
             }));
 
             Steps.Add(new Step<string>(new()
             {
-                Prompt = new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Exclude[/] which object types (semicolon separated list)?").DefaultValue(Options.Exclude),
+                Prompt = new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Exclude[/] which object types (semicolon separated list)?")
+                    .DefaultValue(Options.Exclude),
                 ValueReceiver = (v) => Options.Exclude = v
             }));
 

--- a/src/Wizards/InstallProjectWizard.cs
+++ b/src/Wizards/InstallProjectWizard.cs
@@ -21,7 +21,7 @@ namespace Xperience.Manager.Wizards
         public override async Task InitSteps(params string[] args)
         {
             var versions = await NuGetVersionHelper.GetPackageVersions(Constants.TEMPLATES_PACKAGE);
-            var filtered = versions.Where(v => !v.IsPrerelease && !v.IsLegacyVersion && v.Major >= 25)
+            var filtered = versions.Where(v => !v.IsPrerelease && !v.IsLegacyVersion && v.Major >= Constants.MIN_LISTED_VERSION)
                 .Select(v => v.Version)
                 .OrderByDescending(v => v);
 

--- a/src/Wizards/NewProfileWizard.cs
+++ b/src/Wizards/NewProfileWizard.cs
@@ -20,7 +20,8 @@ namespace Xperience.Manager.Wizards
 
             Steps.Add(new Step<string>(new()
             {
-                Prompt = new TextPrompt<string>($"Enter the [{Constants.PROMPT_COLOR}]full path[/] of the folder containing your Xperience project:"),
+                Prompt = new TextPrompt<string>($"Enter the [{Constants.PROMPT_COLOR}]full path[/] of the folder containing your Xperience " +
+                    "project:"),
                 ValueReceiver = (v) => Options.WorkingDirectory = v,
             }));
 

--- a/src/Wizards/RepositoryConfigurationWizard.cs
+++ b/src/Wizards/RepositoryConfigurationWizard.cs
@@ -34,7 +34,8 @@ namespace Xperience.Manager.Wizards
 
             Steps.Add(new Step<bool>(new()
             {
-                Prompt = new ConfirmationPrompt($"[{Constants.PROMPT_COLOR}]Included[/] object types: {string.Join(";", Options.IncludedObjectTypes ?? Enumerable.Empty<string>())}\nWould you like to change them?")
+                Prompt = new ConfirmationPrompt($"[{Constants.PROMPT_COLOR}]Included[/] object types: {string.Join(";",
+                    Options.IncludedObjectTypes ?? Enumerable.Empty<string>())}\nWould you like to change them?")
                 {
                     DefaultValue = false
                 },
@@ -56,7 +57,8 @@ namespace Xperience.Manager.Wizards
 
             Steps.Add(new Step<bool>(new()
             {
-                Prompt = new ConfirmationPrompt($"[{Constants.PROMPT_COLOR}]Excluded[/] object types: {string.Join(";", Options.ExcludedObjectTypes ?? Enumerable.Empty<string>())}\nWould you like to change them?")
+                Prompt = new ConfirmationPrompt($"[{Constants.PROMPT_COLOR}]Excluded[/] object types: {string.Join(";",
+                    Options.ExcludedObjectTypes ?? Enumerable.Empty<string>())}\nWould you like to change them?")
                 {
                     DefaultValue = false
                 },

--- a/src/Wizards/SettingsWizard.cs
+++ b/src/Wizards/SettingsWizard.cs
@@ -6,12 +6,28 @@ using Xperience.Manager.Steps;
 namespace Xperience.Manager.Wizards
 {
     /// <summary>
-    /// A wizard which generates an <see cref="SettingsOptions"/> for configuring appsettings.json.
+    /// A wizard which generates an <see cref="SettingsOptions"/> for configuring application settings. The 
+    /// <see cref="AbstractWizard{TOptions}.Run(string[])"/> method should be passed a list of available settings files.
     /// </summary>
     public class SettingsWizard : AbstractWizard<SettingsOptions>
     {
         public override Task InitSteps(params string[] args)
         {
+            // List available appsettings files for selection
+            if (args.Length > 1)
+            {
+                Array.Sort(args, (a, b) => a.Length.CompareTo(b.Length));
+                Steps.Add(new Step<string>(new()
+                {
+                    Prompt = new SelectionPrompt<string>()
+                    .Title($"Which [{Constants.PROMPT_COLOR}]file[/] do you want to modify?")
+                    .PageSize(10)
+                    .MoreChoicesText("Scroll for more...")
+                    .AddChoices(args),
+                    ValueReceiver = (v) => Options.AppSettingsFileName = v
+                }));
+            }
+
             Steps.Add(new Step<string>(new()
             {
                 Prompt = new SelectionPrompt<string>()

--- a/src/Wizards/SettingsWizard.cs
+++ b/src/Wizards/SettingsWizard.cs
@@ -20,8 +20,9 @@ namespace Xperience.Manager.Wizards
                     .MoreChoicesText("Scroll for more...")
                     .AddChoices(
                         SettingsOptions.ConnectionStringSetting,
-                        SettingsOptions.ConfigurationKeysSetting,
-                        SettingsOptions.CmsHeadlessSetting
+                        SettingsOptions.UngroupedKeySetting,
+                        SettingsOptions.CmsHeadlessSetting,
+                        SettingsOptions.AzureStorageSetting
                     ),
                 ValueReceiver = (v) => Options.SettingToChange = v
             }));

--- a/src/Wizards/UpdateWizard.cs
+++ b/src/Wizards/UpdateWizard.cs
@@ -14,7 +14,7 @@ namespace Xperience.Manager.Wizards
         public override async Task InitSteps(params string[] args)
         {
             var versions = await NuGetVersionHelper.GetPackageVersions(Constants.TEMPLATES_PACKAGE);
-            var filtered = versions.Where(v => !v.IsPrerelease && !v.IsLegacyVersion && v.Major >= 25)
+            var filtered = versions.Where(v => !v.IsPrerelease && !v.IsLegacyVersion && v.Major >= Constants.MIN_LISTED_VERSION)
                 .Select(v => v.Version)
                 .OrderByDescending(v => v);
 

--- a/test/Data/appsettings.Development.json
+++ b/test/Data/appsettings.Development.json
@@ -1,0 +1,20 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "KenticoEventLog": {
+      "LogLevel": {
+        "Default": "Error",
+        "Microsoft.AspNetCore.Server.Kestrel": "None"
+      }
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "CMSConnectionString": "initial-dev-connection-string"
+  },
+  "CMSHashStringSalt": "initial-dev-hash-string"
+}

--- a/test/Data/appsettings.json
+++ b/test/Data/appsettings.json
@@ -1,0 +1,38 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "KenticoEventLog": {
+      "LogLevel": {
+        "Default": "Error",
+        "Microsoft.AspNetCore.Server.Kestrel": "None"
+      }
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "CMSConnectionString": "initial-connection-string"
+  },
+  "CMSHashStringSalt": "initial-hash-string",
+  "CMSHeadless": {
+    "Enable": true,
+    "EnableComplexity": true,
+    "EnableTracking": true,
+    "AllowIntrospection": false,
+    "GraphQlEndpointPath": "/graphql",
+    "CorsAllowedOrigins": null,
+    "CorsAllowedHeaders": null,
+    "Caching": {
+      "Enable": true,
+      "UseRequestCacheControlHeaders": true,
+      "AddResponseCacheControlHeaders": true,
+      "UseCacheDependencies": true,
+      "AbsoluteExpiration": 720,
+      "SlidingExpiration": 60,
+      "SizeLimit": 100000000
+    }
+  }
+}

--- a/test/Kentico.Xperience.Manager.Tests.csproj
+++ b/test/Kentico.Xperience.Manager.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-		<LangVersion>12.0</LangVersion>
+	<LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Kentico.Xperience.Manager.Tests.csproj
+++ b/test/Kentico.Xperience.Manager.Tests.csproj
@@ -31,6 +31,12 @@
     <None Update="Data\config_with_one_profile.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+	<None Update="Data\appsettings.json">
+		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</None>
+	<None Update="Data\appsettings.Development.json">
+		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</None>
   </ItemGroup>
 
 </Project>

--- a/test/TestBase.cs
+++ b/test/TestBase.cs
@@ -13,7 +13,7 @@ namespace Xperience.Manager.Tests
         /// <summary>
         /// Gets a <see cref="Process"/> which does nothing.
         /// </summary>
-        protected Process GetDummyProcess()
+        protected static Process GetDummyProcess()
         {
             Process cmd = new();
             cmd.StartInfo.FileName = "powershell.exe";

--- a/test/Tests/Commands/CodeGenerateCommandTests.cs
+++ b/test/Tests/Commands/CodeGenerateCommandTests.cs
@@ -48,7 +48,8 @@ namespace Xperience.Manager.Tests.Commands
             await command.PreExecute(new(), string.Empty);
             await command.Execute(new(), string.Empty);
 
-            string expectedCodeGenScript = $"dotnet run -- --kxp-codegen --skip-confirmation --type \"{TYPE}\" --location \"{LOCATION}\" --include \"{INCLUDE}\" --exclude \"{EXCLUDE}\" --with-provider-class {WITH_PROVIDER} --namespace \"{NAMESPACE}\"";
+            string expectedCodeGenScript = $"dotnet run -- --kxp-codegen --skip-confirmation --type \"{TYPE}\" --location \"{LOCATION}\" " +
+                $"--include \"{INCLUDE}\" --exclude \"{EXCLUDE}\" --with-provider-class {WITH_PROVIDER} --namespace \"{NAMESPACE}\"";
 
             shellRunner.Received().Execute(Arg.Is<ShellOptions>(x => x.Script.Equals(expectedCodeGenScript)));
         }

--- a/test/Tests/Commands/ContinuousIntegrationCommandTests.cs
+++ b/test/Tests/Commands/ContinuousIntegrationCommandTests.cs
@@ -16,7 +16,8 @@ namespace Xperience.Manager.Tests.Commands
 
 
         [SetUp]
-        public void ContinuousIntegrationCommandTestsSetUp() => shellRunner.Execute(Arg.Any<ShellOptions>()).Returns((x) => GetDummyProcess());
+        public void ContinuousIntegrationCommandTestsSetUp() => shellRunner.Execute(Arg.Any<ShellOptions>()).Returns((x) =>
+            GetDummyProcess());
 
 
         [Test]

--- a/test/Tests/Commands/InstallCommandTests.cs
+++ b/test/Tests/Commands/InstallCommandTests.cs
@@ -57,7 +57,8 @@ namespace Xperience.Manager.Tests.Commands
             string expectedProjectFileScript = $"dotnet new {TEMPLATE} -n {PROJECT_NAME}";
             string expectedUninstallScript = "dotnet new uninstall kentico.xperience.templates";
             string expectedTemplateScript = $"dotnet new install kentico.xperience.templates::{version}";
-            string expectedDatabaseScript = $"dotnet kentico-xperience-dbmanager -- -s \"{SERVER_NAME}\" -d \"{DB_NAME}\" -a \"{PASSWORD}\" --use-existing-database {USE_EXISTING}";
+            string expectedDatabaseScript = $"dotnet kentico-xperience-dbmanager -- -s \"{SERVER_NAME}\" -d \"{DB_NAME}\" -a " +
+                $"\"{PASSWORD}\" --use-existing-database {USE_EXISTING}";
 
             Assert.Multiple(() =>
             {

--- a/test/Tests/Commands/MacroCommandTests.cs
+++ b/test/Tests/Commands/MacroCommandTests.cs
@@ -38,7 +38,8 @@ namespace Xperience.Manager.Tests.Commands
             await command.PreExecute(new(), string.Empty);
             await command.Execute(new(), string.Empty);
 
-            string expectedMacroScript = $"dotnet run --no-build -- --kxp-resign-macros --sign-all --username \"{USER}\" --new-salt \"{NEW_SALT}\"";
+            string expectedMacroScript = $"dotnet run --no-build -- --kxp-resign-macros --sign-all --username \"{USER}\" --new-salt " +
+                $"\"{NEW_SALT}\"";
 
             shellRunner.Received().Execute(Arg.Is<ShellOptions>(x => x.Script.Equals(expectedMacroScript)));
         }
@@ -56,7 +57,8 @@ namespace Xperience.Manager.Tests.Commands
             await command.PreExecute(new(), string.Empty);
             await command.Execute(new(), string.Empty);
 
-            string expectedMacroScript = $"dotnet run --no-build -- --kxp-resign-macros --old-salt \"{OLD_SALT}\" --new-salt \"{NEW_SALT}\"";
+            string expectedMacroScript = $"dotnet run --no-build -- --kxp-resign-macros --old-salt \"{OLD_SALT}\" --new-salt " +
+                $"\"{NEW_SALT}\"";
 
             shellRunner.Received().Execute(Arg.Is<ShellOptions>(x => x.Script.Equals(expectedMacroScript)));
         }

--- a/test/Tests/Commands/UpdateCommandTests.cs
+++ b/test/Tests/Commands/UpdateCommandTests.cs
@@ -38,15 +38,15 @@ namespace Xperience.Manager.Tests.Commands
             await command.PreExecute(new(), string.Empty);
             await command.Execute(new(), string.Empty);
 
-            string[] packageNames = new string[]
-            {
+            string[] packageNames =
+            [
                 "kentico.xperience.admin",
                 "kentico.xperience.azurestorage",
                 "kentico.xperience.cloud",
                 "kentico.xperience.graphql",
                 "kentico.xperience.imageprocessing",
                 "kentico.xperience.webapp"
-            };
+            ];
 
             foreach (string p in packageNames)
             {

--- a/test/Tests/Services/IAppSettingsManagerTests.cs
+++ b/test/Tests/Services/IAppSettingsManagerTests.cs
@@ -1,0 +1,144 @@
+﻿using NUnit.Framework;
+using Xperience.Manager.Configuration;
+using Xperience.Manager.Services;
+
+namespace Xperience.Manager.Tests.Services
+{
+    /// <summary>
+    /// Tests for <see cref="IAppSettingsManager"/>.
+    /// </summary>
+    public class IAppSettingsManagerTests
+    {
+        private const string DEVELOPMENT_FILE = "appsettings.Development.json";
+        private readonly AppSettingsManager appSettingsManager = new();
+        private readonly ToolProfile profile = new()
+        {
+            ProjectName = "Test",
+            WorkingDirectory = "./Data"
+        };
+
+
+        [Test]
+        public async Task GetConnectionString_GetsStrings()
+        {
+            string expectedDefaultConnectionString = "initial-connection-string";
+            string expectedDevelopmentConnectionString = "initial-dev-connection-string";
+
+            string? defaultConnectionString = await appSettingsManager.GetConnectionString(profile, "CMSConnectionString");
+            string? devConnectionString = await appSettingsManager.GetConnectionString(profile, "CMSConnectionString", DEVELOPMENT_FILE);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(defaultConnectionString, Is.EqualTo(expectedDefaultConnectionString));
+                Assert.That(devConnectionString, Is.EqualTo(expectedDevelopmentConnectionString));
+            });
+        }
+
+
+        [Test]
+        public async Task GetCmsHeadlessConfiguration_GetsHeadlessKeys()
+        {
+            var headlessConfig = await appSettingsManager.GetCmsHeadlessConfiguration(profile);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(headlessConfig.Enable, Is.True);
+                Assert.That(headlessConfig.Caching.SlidingExpiration, Is.EqualTo(60));
+            });
+        }
+
+
+        [Test]
+        public async Task GetConfigurationKeys_UnsetKey_ActualValueUnset()
+        {
+            int logKeepDefaultValue = 10;
+            var keyToRetrieve = new ConfigurationKey("CMSLogKeepPercent", string.Empty, typeof(string), logKeepDefaultValue);
+            var returnedKeys = await appSettingsManager.GetConfigurationKeys(profile, [keyToRetrieve]);
+            var logKeepKey = returnedKeys.FirstOrDefault();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(logKeepKey, Is.Not.Null);
+                Assert.That(logKeepKey?.ActualValue, Is.Null);
+                Assert.That(logKeepKey?.DefaultValue, Is.EqualTo(logKeepDefaultValue));
+            });
+        }
+
+
+        [Test]
+        public async Task GetConfigurationKeys_SetKey_ActualValueSet()
+        {
+            string expectedDefaultHashString = "initial-hash-string";
+            string expectedDevelopmentHashString = "initial-dev-hash-string";
+
+            var keyToRetrieve = new ConfigurationKey("CMSHashStringSalt", string.Empty, typeof(string));
+            var defaultReturnedKeys = await appSettingsManager.GetConfigurationKeys(profile, [keyToRetrieve]);
+            object? defaultHashStringValue = defaultReturnedKeys.FirstOrDefault()?.ActualValue;
+            var developmentReturnedKeys = await appSettingsManager.GetConfigurationKeys(profile, [keyToRetrieve], DEVELOPMENT_FILE);
+            object? developmentHashStringValue = developmentReturnedKeys.FirstOrDefault()?.ActualValue;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(defaultHashStringValue?.ToString(), Is.EqualTo(expectedDefaultHashString));
+                Assert.That(developmentHashStringValue?.ToString(), Is.EqualTo(expectedDevelopmentHashString));
+            });
+        }
+
+
+        [Test]
+        public async Task SetCmsHeadlessConfiguration_UpdatesValue()
+        {
+            int expectedSlidingExpiration = 100;
+            var initialHeadlessConfig = await appSettingsManager.GetCmsHeadlessConfiguration(profile);
+
+            initialHeadlessConfig.Caching.SlidingExpiration = expectedSlidingExpiration;
+            await appSettingsManager.SetCmsHeadlessConfiguration(profile, initialHeadlessConfig);
+            var updatedHeadlessConfig = await appSettingsManager.GetCmsHeadlessConfiguration(profile);
+
+            Assert.That(updatedHeadlessConfig.Caching.SlidingExpiration, Is.EqualTo(expectedSlidingExpiration));
+        }
+
+
+        [Test]
+        public async Task SetConnectionString_SetsConnectionString()
+        {
+            string connectionStringName = "CMSConnectionString";
+            string expectedDefaultConnectionString = "updated-connection-string";
+            string expectedDevelopmentConnectionString = "updated-dev-connection-string";
+
+            await appSettingsManager.SetConnectionString(profile, connectionStringName, expectedDefaultConnectionString);
+            await appSettingsManager.SetConnectionString(profile, connectionStringName, expectedDevelopmentConnectionString, DEVELOPMENT_FILE);
+            string? updatedDefaultConnectionString = await appSettingsManager.GetConnectionString(profile, connectionStringName);
+            string? updatedDevelopmentConnectionString = await appSettingsManager.GetConnectionString(profile, connectionStringName, DEVELOPMENT_FILE);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedDefaultConnectionString, Is.EqualTo(expectedDefaultConnectionString));
+                Assert.That(updatedDevelopmentConnectionString?.ToString(), Is.EqualTo(expectedDevelopmentConnectionString));
+            });
+        }
+
+
+        [Test]
+        public async Task SetKeyValue_SetsKeyValue()
+        {
+            string keyName = "CMSAzureAccountName";
+            string expectedAzureAccountName = "testAccount";
+
+            await appSettingsManager.SetKeyValue(profile, keyName, expectedAzureAccountName);
+            await appSettingsManager.SetKeyValue(profile, keyName, expectedAzureAccountName, DEVELOPMENT_FILE);
+
+            var keyToRetrieve = new ConfigurationKey(keyName, string.Empty, typeof(string));
+            var updatedDefaultKeys = await appSettingsManager.GetConfigurationKeys(profile, [keyToRetrieve]);
+            object? updatedDefaultAzureAccountName = updatedDefaultKeys.FirstOrDefault()?.ActualValue;
+            var updatedDevelopmentKeys = await appSettingsManager.GetConfigurationKeys(profile, [keyToRetrieve], DEVELOPMENT_FILE);
+            object? updatedDevelopmentAzureAccountName = updatedDevelopmentKeys.FirstOrDefault()?.ActualValue;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedDefaultAzureAccountName?.ToString(), Is.EqualTo(expectedAzureAccountName));
+                Assert.That(updatedDevelopmentAzureAccountName?.ToString(), Is.EqualTo(expectedAzureAccountName));
+            });
+        }
+    }
+}

--- a/test/Tests/Services/IConfigManagerTests.cs
+++ b/test/Tests/Services/IConfigManagerTests.cs
@@ -10,7 +10,7 @@ namespace Xperience.Manager.Tests.Services
     /// </summary>
     public class IConfigManagerTests : TestBase
     {
-        private readonly IConfigManager configManager = new ConfigManager();
+        private readonly ConfigManager configManager = new();
 
 
         [Test]
@@ -57,7 +57,7 @@ namespace Xperience.Manager.Tests.Services
             await configManager.AddProfile(p2);
             var config = await configManager.GetConfig();
 
-            Assert.That(config.Profiles.Count, Is.EqualTo(2));
+            Assert.That(config.Profiles, Has.Count.EqualTo(2));
         }
 
 
@@ -88,7 +88,7 @@ namespace Xperience.Manager.Tests.Services
             await configManager.RemoveProfile(profile);
             var config = await configManager.GetConfig();
 
-            Assert.That(config.Profiles.Count, Is.EqualTo(1));
+            Assert.That(config.Profiles, Has.Count.EqualTo(1));
         }
 
 

--- a/test/Tests/Services/IScriptBuilderTests.cs
+++ b/test/Tests/Services/IScriptBuilderTests.cs
@@ -10,7 +10,7 @@ namespace Xperience.Manager.Tests.Services
     /// </summary>
     public class IScriptBuilderTests
     {
-        private readonly IScriptBuilder scriptBuilder = new ScriptBuilder();
+        private readonly ScriptBuilder scriptBuilder = new();
         private readonly InstallProjectOptions validProjectOptions = new()
         {
             ProjectName = "TEST",
@@ -67,7 +67,9 @@ namespace Xperience.Manager.Tests.Services
         public void DatabaseInstallScript_WithValidOptions_ReturnsValidScript()
         {
             string script = scriptBuilder.SetScript(ScriptType.DatabaseInstall).WithPlaceholders(validDatabaseOptions).Build();
-            string expected = $"dotnet kentico-xperience-dbmanager -- -s \"{validDatabaseOptions.ServerName}\" -d \"{validDatabaseOptions.DatabaseName}\" -a \"{validDatabaseOptions.AdminPassword}\" --use-existing-database {validDatabaseOptions.UseExistingDatabase}";
+            string expected = $"dotnet kentico-xperience-dbmanager -- -s \"{validDatabaseOptions.ServerName}\" -d \"" +
+                $"{validDatabaseOptions.DatabaseName}\" -a \"{validDatabaseOptions.AdminPassword}\" --use-existing-database " +
+                $"{validDatabaseOptions.UseExistingDatabase}";
 
             Assert.That(script, Is.EqualTo(expected));
         }

--- a/test/Tests/Services/IShellRunnerTests.cs
+++ b/test/Tests/Services/IShellRunnerTests.cs
@@ -12,7 +12,7 @@ namespace Xperience.Manager.Tests.Services
     /// </summary>
     public class IShellRunnerTests
     {
-        private readonly IShellRunner shellRunner = new ShellRunner();
+        private readonly ShellRunner shellRunner = new();
 
 
         [Test]


### PR DESCRIPTION
# Motivation

- Adds new Headless configuration keys `EnableComplexity` and `EnableTracking`
- Adds new general configuration keys `CMSBuilderScriptsIncludeJQuery`, `CMSDeleteTemporaryUploadFilesOlderThan`, `CMSPhysicalFilesCacheMinutes`, and `CMSStorageProviderAssembly`
- Adds all configuration keys related to [Azure storage](https://docs.kentico.com/developers-and-admins/api/files-api-and-cms-io/file-system-providers/azure-blob-storage)
- `settings` command now shows default values for unset keys during listing
- `settings` command can now modify multiple configuration files in the project (appsettings.Development.json, etc.)
- Configuration key values are escaped with Spectre.Console [`Markup`](https://spectreconsole.net/markup)
- Adds `IAppSettingsManagerTests`

## Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
