### PR TITLE
Allow username and password authentication during installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 7.0.x
     - name: Restore dependencies

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Company>Kentico</Company>
     <Authors>Eric Dugre</Authors>
-    <VersionPrefix>5.3.0</VersionPrefix>
+    <VersionPrefix>5.4.0</VersionPrefix>
     <Product>Xperience by Kentico</Product>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docs/Usage-Guide.md
+++ b/docs/Usage-Guide.md
@@ -25,13 +25,15 @@ The `xman.json` file contains information about the tool, your default options, 
   "DefaultInstallDatabaseOptions": {
     "UseExistingDatabase": false,
     "DatabaseName": "xperience",
-    "ServerName": "my-server"
+    "ServerName": "my-server",
+    "DatabaseUserName": "admin-user",
+    "DatabasePassword": "dbpassword"
   },
   "CDRootPath": "C:\\inetpub\\wwwroot\\ContinuousDeployment"
 }
 ```
 
-You can edit this file to change the `DefaultInstallProjectOptions` used when [installing](#installing-a-new-project) new Xperience by Kentico projects, and the location of the [Continuous Deployment](#running-continuous-deployment) files.
+You can edit this file to change the `DefaultInstallProjectOptions` or `DefaultInstallDatabaseOptions` used when [installing](#installing-a-new-project) new Xperience by Kentico projects, and the location of the [Continuous Deployment](#running-continuous-deployment) files.
 
 ## Commands
 
@@ -87,7 +89,7 @@ The installation wizard will automatically generate an administrator password fo
    xman install
    ```
 
-Installing a new project automatically includes a database as well. If you want to _only_ install a database and not the project files, use the __db__ parameter: `xman install db`.
+Installing a new project automatically includes a database as well. If you want to _only_ install a database and not the project files, use the __db__ parameter: `xman install db`. During database installation you can choose to use __Integrated__ (Windows Authentication) or __User__ authentication. If you choose User authentication, you will be prompted to enter the credentials for a SQL Server user (or use the default values from the [configuration file](#configuration-file)).
 
 ### Updating a project version
 

--- a/src/Commands/InstallCommand.cs
+++ b/src/Commands/InstallCommand.cs
@@ -172,6 +172,7 @@ namespace Xperience.Manager.Commands
 
             string databaseScript = scriptBuilder.SetScript(ScriptType.DatabaseInstall)
                 .WithPlaceholders(options)
+                .AppendDatabaseCredentials(options.DatabaseUserName, options.DatabasePassword)
                 .Build();
             // Database-only install requires removal of "dotnet" from the script to run global tool
             if (isDatabaseOnly)

--- a/src/Commands/InstallCommand.cs
+++ b/src/Commands/InstallCommand.cs
@@ -172,7 +172,11 @@ namespace Xperience.Manager.Commands
 
             string databaseScript = scriptBuilder.SetScript(ScriptType.DatabaseInstall)
                 .WithPlaceholders(options)
-                .AppendDatabaseCredentials(options.DatabaseUserName, options.DatabasePassword)
+                .AppendDatabaseCredentials(
+                    options.DatabaseAuthenticationType?
+                        .Equals(InstallDatabaseOptions.AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase) ?? true,
+                    options.DatabaseUserName,
+                    options.DatabasePassword)
                 .Build();
             // Database-only install requires removal of "dotnet" from the script to run global tool
             if (isDatabaseOnly)

--- a/src/Commands/InstallCommand.cs
+++ b/src/Commands/InstallCommand.cs
@@ -170,14 +170,14 @@ namespace Xperience.Manager.Commands
 
             AnsiConsole.MarkupLineInterpolated($"[{Constants.EMPHASIS_COLOR}]Running database creation script...[/]");
 
-            string databaseScript = scriptBuilder.SetScript(ScriptType.DatabaseInstall)
-                .WithPlaceholders(options)
-                .AppendDatabaseCredentials(
-                    options.DatabaseAuthenticationType?
-                        .Equals(InstallDatabaseOptions.AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase) ?? true,
-                    options.DatabaseUserName,
-                    options.DatabasePassword)
-                .Build();
+            var databaseScriptBuilder = scriptBuilder.SetScript(ScriptType.DatabaseInstall).WithPlaceholders(options);
+            if (options.DatabaseAuthenticationType?
+                .Equals(InstallDatabaseOptions.AUTHENTICATION_USER, StringComparison.InvariantCultureIgnoreCase) ?? false)
+            {
+                databaseScriptBuilder.AppendDatabaseCredentials(options.DatabaseUserName, options.DatabasePassword);
+            }
+            string databaseScript = databaseScriptBuilder.Build();
+
             // Database-only install requires removal of "dotnet" from the script to run global tool
             if (isDatabaseOnly)
             {

--- a/src/Commands/UpdateCommand.cs
+++ b/src/Commands/UpdateCommand.cs
@@ -23,7 +23,8 @@ namespace Xperience.Manager.Commands
             "kentico.xperience.cloud",
             "kentico.xperience.graphql",
             "kentico.xperience.imageprocessing",
-            "kentico.xperience.webapp"
+            "kentico.xperience.webapp",
+            "kentico.xperience.mjml"
         ];
 
 

--- a/src/Kentico.Xperience.Manager.csproj
+++ b/src/Kentico.Xperience.Manager.csproj
@@ -21,11 +21,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Autofac" Version="7.1.0" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="nuget.protocol" Version="6.8.0" />
-		<PackageReference Include="Spectre.Console" Version="0.53.1" />
+		<PackageReference Include="Autofac" Version="9.1.0" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="nuget.protocol" Version="7.3.1" />
+		<PackageReference Include="Spectre.Console" Version="0.55.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
 	</ItemGroup>
 

--- a/src/Options/InstallDatabaseOptions.cs
+++ b/src/Options/InstallDatabaseOptions.cs
@@ -28,6 +28,18 @@ namespace Xperience.Manager.Options
 
 
         /// <summary>
+        /// User name for database authentication.
+        /// </summary>
+        public string? DatabaseUserName { get; set; }
+
+
+        /// <summary>
+        /// Password for database authentication.
+        /// </summary>
+        public string? DatabasePassword { get; set; }
+
+
+        /// <summary>
         /// The name of the global administrator password.
         /// </summary>
         [JsonIgnore]

--- a/src/Options/InstallDatabaseOptions.cs
+++ b/src/Options/InstallDatabaseOptions.cs
@@ -9,6 +9,10 @@ namespace Xperience.Manager.Options
     /// </summary>
     public class InstallDatabaseOptions : IWizardOptions
     {
+        public const string AUTHENTICATION_USER = "User";
+        public const string AUTHENTICATION_INTEGRATED = "Integrated";
+
+
         /// <summary>
         /// The name of the new database.
         /// </summary>
@@ -25,6 +29,13 @@ namespace Xperience.Manager.Options
         /// The name of the SQL server to use.
         /// </summary>
         public string? ServerName { get; set; }
+
+
+        /// <summary>
+        /// The type of authentication to connect to the database.
+        /// </summary>
+        [JsonIgnore]
+        public string? DatabaseAuthenticationType { get; set; }
 
 
         /// <summary>

--- a/src/Services/Interfaces/IScriptBuilder.cs
+++ b/src/Services/Interfaces/IScriptBuilder.cs
@@ -19,12 +19,10 @@ namespace Xperience.Manager.Services
 
 
         /// <summary>
-        /// Appends the database credentials if they are not empty or null and the script is <see cref="ScriptType.DatabaseInstall"/>.
+        /// Appends the database credentials if they are not empty or null, the authentication type is not "Integrated," and the script is
+        /// <see cref="ScriptType.DatabaseInstall"/>.
         /// </summary>
-        /// <param name="databaseUserName"></param>
-        /// <param name="databasePassword"></param>
-        /// <returns></returns>
-        public IScriptBuilder AppendDatabaseCredentials(string? databaseUserName, string? databasePassword);
+        public IScriptBuilder AppendDatabaseCredentials(bool isIntegrated, string? databaseUserName, string? databasePassword);
 
 
         /// <summary>

--- a/src/Services/Interfaces/IScriptBuilder.cs
+++ b/src/Services/Interfaces/IScriptBuilder.cs
@@ -19,10 +19,9 @@ namespace Xperience.Manager.Services
 
 
         /// <summary>
-        /// Appends the database credentials if they are not empty or null, the authentication type is not "Integrated," and the script is
-        /// <see cref="ScriptType.DatabaseInstall"/>.
+        /// Appends the database credentials if they are not empty or null, and the script is <see cref="ScriptType.DatabaseInstall"/>.
         /// </summary>
-        public IScriptBuilder AppendDatabaseCredentials(bool isIntegrated, string? databaseUserName, string? databasePassword);
+        public IScriptBuilder AppendDatabaseCredentials(string? databaseUserName, string? databasePassword);
 
 
         /// <summary>

--- a/src/Services/Interfaces/IScriptBuilder.cs
+++ b/src/Services/Interfaces/IScriptBuilder.cs
@@ -19,6 +19,15 @@ namespace Xperience.Manager.Services
 
 
         /// <summary>
+        /// Appends the database credentials if they are not empty or null and the script is <see cref="ScriptType.DatabaseInstall"/>.
+        /// </summary>
+        /// <param name="databaseUserName"></param>
+        /// <param name="databasePassword"></param>
+        /// <returns></returns>
+        public IScriptBuilder AppendDatabaseCredentials(string? databaseUserName, string? databasePassword);
+
+
+        /// <summary>
         /// Appends the namespace to use if the script is <see cref="ScriptType.GenerateCode"/> and <paramref name="nameSpace"/>
         /// is not empty.
         /// </summary>

--- a/src/Services/ScriptBuilder.cs
+++ b/src/Services/ScriptBuilder.cs
@@ -59,9 +59,9 @@ namespace Xperience.Manager.Services
         }
 
 
-        public IScriptBuilder AppendDatabaseCredentials(bool isIntegrated, string? databaseUserName, string? databasePassword)
+        public IScriptBuilder AppendDatabaseCredentials(string? databaseUserName, string? databasePassword)
         {
-            if (!isIntegrated && currentScriptType.Equals(ScriptType.DatabaseInstall) &&
+            if (currentScriptType.Equals(ScriptType.DatabaseInstall) &&
                 !string.IsNullOrEmpty(databaseUserName) && !string.IsNullOrEmpty(databasePassword))
             {
                 currentScript += $" -u \"{databaseUserName}\" -p \"{databasePassword}\"";

--- a/src/Services/ScriptBuilder.cs
+++ b/src/Services/ScriptBuilder.cs
@@ -59,6 +59,18 @@ namespace Xperience.Manager.Services
         }
 
 
+        public IScriptBuilder AppendDatabaseCredentials(string? databaseUserName, string? databasePassword)
+        {
+            if (currentScriptType.Equals(ScriptType.DatabaseInstall) &&
+                !string.IsNullOrEmpty(databaseUserName) && !string.IsNullOrEmpty(databasePassword))
+            {
+                currentScript += $" -u \"{databaseUserName}\" -p \"{databasePassword}\"";
+            }
+
+            return this;
+        }
+
+
         public IScriptBuilder AppendNamespace(string? nameSpace)
         {
             if (currentScriptType.Equals(ScriptType.GenerateCode) && !string.IsNullOrEmpty(nameSpace))

--- a/src/Services/ScriptBuilder.cs
+++ b/src/Services/ScriptBuilder.cs
@@ -59,9 +59,9 @@ namespace Xperience.Manager.Services
         }
 
 
-        public IScriptBuilder AppendDatabaseCredentials(string? databaseUserName, string? databasePassword)
+        public IScriptBuilder AppendDatabaseCredentials(bool isIntegrated, string? databaseUserName, string? databasePassword)
         {
-            if (currentScriptType.Equals(ScriptType.DatabaseInstall) &&
+            if (!isIntegrated && currentScriptType.Equals(ScriptType.DatabaseInstall) &&
                 !string.IsNullOrEmpty(databaseUserName) && !string.IsNullOrEmpty(databasePassword))
             {
                 currentScript += $" -u \"{databaseUserName}\" -p \"{databasePassword}\"";

--- a/src/Wizards/InstallDatabaseWizard.cs
+++ b/src/Wizards/InstallDatabaseWizard.cs
@@ -11,8 +11,6 @@ namespace Xperience.Manager.Wizards
     public class InstallDatabaseWizard : AbstractWizard<InstallDatabaseOptions>
     {
         public const string SKIP_EXISTINGDB_STEP = "skipexistingdbstep";
-        private const string AUTHENTICATION_USER = "User";
-        private const string AUTHENTICATION_INTEGRATED = "Integrated";
 
 
         public override Task InitSteps(params string[] args)
@@ -37,27 +35,38 @@ namespace Xperience.Manager.Wizards
             }));
 
             // Integrated or user/pass database authentication
-            string authenticationType = AUTHENTICATION_INTEGRATED;
             Steps.Add(new Step<string>(new()
             {
                 Prompt = new SelectionPrompt<string>()
                     .Title($"Database [{Constants.PROMPT_COLOR}]authentication method[/]?")
-                    .AddChoices(AUTHENTICATION_INTEGRATED, AUTHENTICATION_USER),
-                ValueReceiver = (v) => authenticationType = v
+                    .AddChoices(InstallDatabaseOptions.AUTHENTICATION_INTEGRATED, InstallDatabaseOptions.AUTHENTICATION_USER),
+                ValueReceiver = (v) => Options.DatabaseAuthenticationType = v
             }));
 
+            var databaseUserNamePrompt = new TextPrompt<string>($"Database [{Constants.PROMPT_COLOR}]user name[/]:");
+            if (!string.IsNullOrEmpty(Options.DatabaseUserName))
+            {
+                databaseUserNamePrompt.DefaultValue(Options.DatabaseUserName);
+            }
             Steps.Add(new Step<string>(new()
             {
-                Prompt = new TextPrompt<string>($"Database [{Constants.PROMPT_COLOR}]user name[/]:"),
+                Prompt = databaseUserNamePrompt,
                 ValueReceiver = (v) => Options.DatabaseUserName = v,
-                SkipChecker = () => authenticationType.Equals(AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase)
+                SkipChecker = () => Options.DatabaseAuthenticationType?
+                    .Equals(InstallDatabaseOptions.AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase) ?? false
             }));
 
+            var databasePasswordPrompt = new TextPrompt<string>($"Database [{Constants.PROMPT_COLOR}]password[/]:");
+            if (!string.IsNullOrEmpty(Options.DatabasePassword))
+            {
+                databasePasswordPrompt.DefaultValue(Options.DatabasePassword);
+            }
             Steps.Add(new Step<string>(new()
             {
-                Prompt = new TextPrompt<string>($"Database [{Constants.PROMPT_COLOR}]password[/]:"),
+                Prompt = databasePasswordPrompt,
                 ValueReceiver = (v) => Options.DatabasePassword = v,
-                SkipChecker = () => authenticationType.Equals(AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase)
+                SkipChecker = () => Options.DatabaseAuthenticationType?
+                    .Equals(InstallDatabaseOptions.AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase) ?? false
             }));
 
             var useExistingPrompt = new ConfirmationPrompt($"Use [{Constants.PROMPT_COLOR}]existing[/] database?")

--- a/src/Wizards/InstallDatabaseWizard.cs
+++ b/src/Wizards/InstallDatabaseWizard.cs
@@ -11,6 +11,8 @@ namespace Xperience.Manager.Wizards
     public class InstallDatabaseWizard : AbstractWizard<InstallDatabaseOptions>
     {
         public const string SKIP_EXISTINGDB_STEP = "skipexistingdbstep";
+        private const string AUTHENTICATION_USER = "User";
+        private const string AUTHENTICATION_INTEGRATED = "Integrated";
 
 
         public override Task InitSteps(params string[] args)
@@ -32,6 +34,30 @@ namespace Xperience.Manager.Wizards
                     .AllowEmpty()
                     .DefaultValue(Options.DatabaseName),
                 ValueReceiver = (v) => Options.DatabaseName = v
+            }));
+
+            // Integrated or user/pass database authentication
+            string authenticationType = AUTHENTICATION_INTEGRATED;
+            Steps.Add(new Step<string>(new()
+            {
+                Prompt = new SelectionPrompt<string>()
+                    .Title($"Database [{Constants.PROMPT_COLOR}]authentication method[/]?")
+                    .AddChoices(AUTHENTICATION_INTEGRATED, AUTHENTICATION_USER),
+                ValueReceiver = (v) => authenticationType = v
+            }));
+
+            Steps.Add(new Step<string>(new()
+            {
+                Prompt = new TextPrompt<string>($"Database [{Constants.PROMPT_COLOR}]user name[/]:"),
+                ValueReceiver = (v) => Options.DatabaseUserName = v,
+                SkipChecker = () => authenticationType.Equals(AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase)
+            }));
+
+            Steps.Add(new Step<string>(new()
+            {
+                Prompt = new TextPrompt<string>($"Database [{Constants.PROMPT_COLOR}]password[/]:"),
+                ValueReceiver = (v) => Options.DatabasePassword = v,
+                SkipChecker = () => authenticationType.Equals(AUTHENTICATION_INTEGRATED, StringComparison.InvariantCultureIgnoreCase)
             }));
 
             var useExistingPrompt = new ConfirmationPrompt($"Use [{Constants.PROMPT_COLOR}]existing[/] database?")

--- a/test/Tests/Commands/InstallCommandTests.cs
+++ b/test/Tests/Commands/InstallCommandTests.cs
@@ -28,7 +28,6 @@ namespace Xperience.Manager.Tests.Commands
         private readonly IAnsiConsole originalConsole = AnsiConsole.Console;
         private readonly IShellRunner shellRunner = Substitute.For<IShellRunner>();
         private readonly IWizard<InstallProjectOptions> projectWizard = Substitute.For<IWizard<InstallProjectOptions>>();
-        //private readonly IWizard<InstallDatabaseOptions> dbWizard = Substitute.For<IWizard<InstallDatabaseOptions>>();
 
 
         [SetUp]

--- a/test/Tests/Commands/InstallCommandTests.cs
+++ b/test/Tests/Commands/InstallCommandTests.cs
@@ -17,16 +17,18 @@ namespace Xperience.Manager.Tests.Commands
     public class InstallCommandTests : TestBase
     {
         private const string DB_NAME = "TESTDB";
-        private const string PASSWORD = "PW";
+        private const string ADMIN_PASSWORD = "PW";
         private const string SERVER_NAME = "TESTSERVER";
         private const string TEMPLATE = "TEMPLATE";
         private const string PROJECT_NAME = "PROJECT";
+        private const string DB_USER = "DBUSER";
+        private const string DB_PASSWORD = "DBPASS";
         private const bool USE_EXISTING = false;
         private readonly Version version = new(1, 0, 0);
         private readonly IAnsiConsole originalConsole = AnsiConsole.Console;
         private readonly IShellRunner shellRunner = Substitute.For<IShellRunner>();
         private readonly IWizard<InstallProjectOptions> projectWizard = Substitute.For<IWizard<InstallProjectOptions>>();
-        private readonly IWizard<InstallDatabaseOptions> dbWizard = Substitute.For<IWizard<InstallDatabaseOptions>>();
+        //private readonly IWizard<InstallDatabaseOptions> dbWizard = Substitute.For<IWizard<InstallDatabaseOptions>>();
 
 
         [SetUp]
@@ -37,13 +39,6 @@ namespace Xperience.Manager.Tests.Commands
                 ProjectName = PROJECT_NAME,
                 Version = version,
                 Template = TEMPLATE
-            });
-            dbWizard.Run().Returns(new InstallDatabaseOptions
-            {
-                AdminPassword = PASSWORD,
-                DatabaseName = DB_NAME,
-                ServerName = SERVER_NAME,
-                UseExistingDatabase = USE_EXISTING
             });
 
             // Use mock console to ignore new profile prompt
@@ -59,7 +54,16 @@ namespace Xperience.Manager.Tests.Commands
         [Test]
         public async Task Execute_CallsInstallationScripts()
         {
+            var dbWizard = Substitute.For<IWizard<InstallDatabaseOptions>>();
+            dbWizard.Run().Returns(new InstallDatabaseOptions
+            {
+                AdminPassword = ADMIN_PASSWORD,
+                DatabaseName = DB_NAME,
+                ServerName = SERVER_NAME,
+                UseExistingDatabase = USE_EXISTING
+            });
             var command = new InstallCommand(shellRunner, new ScriptBuilder(), projectWizard, dbWizard, Substitute.For<IConfigManager>());
+
             await command.PreExecute(new(), string.Empty);
             await command.Execute(new(), string.Empty);
 
@@ -67,7 +71,7 @@ namespace Xperience.Manager.Tests.Commands
             string expectedUninstallScript = "dotnet new uninstall kentico.xperience.templates";
             string expectedTemplateScript = $"dotnet new install kentico.xperience.templates::{version}";
             string expectedDatabaseScript = $"dotnet kentico-xperience-dbmanager -- -s \"{SERVER_NAME}\" -d \"{DB_NAME}\" -a " +
-                $"\"{PASSWORD}\" --use-existing-database {USE_EXISTING}";
+                $"\"{ADMIN_PASSWORD}\" --use-existing-database {USE_EXISTING}";
 
             Assert.Multiple(() =>
             {
@@ -76,6 +80,31 @@ namespace Xperience.Manager.Tests.Commands
                 shellRunner.Received().Execute(Arg.Is<ShellOptions>(x => x.Script.Equals(expectedTemplateScript)));
                 shellRunner.Received().Execute(Arg.Is<ShellOptions>(x => x.Script.Equals(expectedDatabaseScript)));
             });
+        }
+
+
+        [Test]
+        public async Task Execute_WithCredentials_UsesCredentials()
+        {
+            var dbWizard = Substitute.For<IWizard<InstallDatabaseOptions>>();
+            dbWizard.Run().Returns(new InstallDatabaseOptions
+            {
+                AdminPassword = ADMIN_PASSWORD,
+                DatabaseName = DB_NAME,
+                ServerName = SERVER_NAME,
+                UseExistingDatabase = USE_EXISTING,
+                DatabaseAuthenticationType = InstallDatabaseOptions.AUTHENTICATION_USER,
+                DatabaseUserName = DB_USER,
+                DatabasePassword = DB_PASSWORD
+            });
+            var command = new InstallCommand(shellRunner, new ScriptBuilder(), projectWizard, dbWizard, Substitute.For<IConfigManager>());
+
+            await command.PreExecute(new(), string.Empty);
+            await command.Execute(new(), string.Empty);
+
+            string expectedDatabaseScript = $"dotnet kentico-xperience-dbmanager -- -s \"{SERVER_NAME}\" -d \"{DB_NAME}\" -a " +
+                $"\"{ADMIN_PASSWORD}\" --use-existing-database {USE_EXISTING} -u \"{DB_USER}\" -p \"{DB_PASSWORD}\"";
+            shellRunner.Received().Execute(Arg.Is<ShellOptions>(x => x.Script.Equals(expectedDatabaseScript)));
         }
     }
 }

--- a/test/Tests/Commands/UpdateCommandTests.cs
+++ b/test/Tests/Commands/UpdateCommandTests.cs
@@ -51,7 +51,8 @@ namespace Xperience.Manager.Tests.Commands
                 "kentico.xperience.cloud",
                 "kentico.xperience.graphql",
                 "kentico.xperience.imageprocessing",
-                "kentico.xperience.webapp"
+                "kentico.xperience.webapp",
+                "kentico.xperience.mjml"
             ];
 
             foreach (string p in packageNames)


### PR DESCRIPTION
# Motivation

- Implements #17, with support for adding default username/password values in configuration file
- Adds `kentico.xperience.mjml` to the list of packages managed by the tool
- Updates several referenced packages, including vulnerable NuGet.Protocol package


## Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
