### PR TITLE
KX-23649 - Sign DLLs using short-lived access tokens

### DIFF
--- a/.azuredevops/pipelines/build-and-release.yml
+++ b/.azuredevops/pipelines/build-and-release.yml
@@ -47,6 +47,14 @@ stages:
               feedsToUse: select
               restoreArguments: --locked-mode
 
+          - task: GetAzureAuthToken@5
+            name: KeyVaultToken
+            displayName: Get token to code signing certificate
+            inputs:
+              ServiceConnection: Code signer
+              AccessScopes: https://vault.azure.net/.default
+
+          - task: DotNetCoreCLI@2
           - task: DotNetCoreCLI@2
             displayName: Build
             inputs:
@@ -55,7 +63,7 @@ stages:
               configuration: ${{ variables.Configuration }}
               arguments: --no-restore
             env:
-              AuthenticodeClientSecret: $(AuthenticodeClientSecret)
+              AuthenticodeAccessToken: $(KeyVaultToken.AuthToken)
               # Roll-forward behavior set for AzureSignTool dotnet tool (see .config\dotnet-tools.json) which requires .Net 6.0 runtime
               DOTNET_ROLL_FORWARD: Major
 

--- a/.azuredevops/pipelines/build-and-release.yml
+++ b/.azuredevops/pipelines/build-and-release.yml
@@ -55,7 +55,6 @@ stages:
               AccessScopes: https://vault.azure.net/.default
 
           - task: DotNetCoreCLI@2
-          - task: DotNetCoreCLI@2
             displayName: Build
             inputs:
               command: build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,4 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <PropertyGroup>
-    <TimestampServerUrl>http://timestamp.digicert.com</TimestampServerUrl>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-    <Target Name="SignAssemblyWithAuthenticodeSignature" AfterTargets="AfterBuild" Condition="'$(MSBuildProjectFullPath.Contains(&quot;node_modules&quot;))' == 'false' And $(Configuration) == 'Release' And $(SIGN_FILE) != 'false'">
+    <Target Name="SignAssemblyWithAuthenticodeSignature" AfterTargets="AfterBuild" Condition="'$(MSBuildProjectFullPath.Contains(&quot;node_modules&quot;))' == 'false' And $(Configuration) == 'Release' And $(SIGN_FILE) == 'true'">
         <PropertyGroup>
             <XmlSerializersTargetPath>$(TargetDir)$(TargetName).XmlSerializers.dll</XmlSerializersTargetPath>
         </PropertyGroup>
@@ -9,6 +9,6 @@
             <AssemblyToSign Include="$(XmlSerializersTargetPath)" Condition="Exists('$(XmlSerializersTargetPath)')" />
         </ItemGroup>
 
-        <Exec Command="dotnet AzureSignTool sign --azure-key-vault-url $(AuthenticodeKeyVaultUrl) --azure-key-vault-tenant-id $(AuthenticodeTenantId) --azure-key-vault-client-id $(AuthenticodeClientId) --azure-key-vault-client-secret $(AuthenticodeClientSecret) --azure-key-vault-certificate $(AuthenticodeCertificateName) --timestamp-rfc3161 $(TimestampServerUrl) --skip-signed %(AssemblyToSign.Identity)" />
+        <Exec Command="dotnet AzureSignTool sign --azure-key-vault-url $(AuthenticodeKeyVaultUrl) --azure-key-vault-accesstoken $(AuthenticodeAccessToken) --azure-key-vault-certificate $(AuthenticodeCertificateName) --timestamp-rfc3161 $(TimestampServerUrl) --skip-signed %(AssemblyToSign.Identity)" />
     </Target>
 </Project>


### PR DESCRIPTION
# Motivation
Changes the way we access the code signing certificate. Instead of client id/client secret, we use short-lived access tokens.